### PR TITLE
Add installment credit support

### DIFF
--- a/contracts/CreditAgent.sol
+++ b/contracts/CreditAgent.sol
@@ -290,7 +290,7 @@ contract CreditAgent is
             durationsInPeriods.length != borrowAmounts.length ||
             durationsInPeriods.length != addonAmounts.length
         ) {
-            revert CreditAgent_InvalidInputArrays();
+            revert CreditAgent_InputArraysInvalid();
         }
         for (uint256 i = 0; i < borrowAmounts.length; i++) {
             if (durationsInPeriods[i] == 0) {

--- a/contracts/CreditAgent.sol
+++ b/contracts/CreditAgent.sol
@@ -77,8 +77,8 @@ contract CreditAgent is
     /// @dev The bit flags that represent the required hooks for cash-out operations.
     uint256 private constant REQUIRED_CASHIER_CASH_OUT_HOOK_FLAGS =
         (1 << uint256(ICashierHookableTypes.HookIndex.CashOutRequestBefore)) +
-            (1 << uint256(ICashierHookableTypes.HookIndex.CashOutConfirmationAfter)) +
-            (1 << uint256(ICashierHookableTypes.HookIndex.CashOutReversalAfter));
+        (1 << uint256(ICashierHookableTypes.HookIndex.CashOutConfirmationAfter)) +
+        (1 << uint256(ICashierHookableTypes.HookIndex.CashOutReversalAfter));
 
     // ------------------ Modifiers ------------------------------- //
 

--- a/contracts/CreditAgent.sol
+++ b/contracts/CreditAgent.sol
@@ -553,6 +553,7 @@ contract CreditAgent is
         CreditStatus newStatus,
         CreditStatus oldStatus
     ) internal {
+        uint256 installmentCount = installmentCredit.durationsInPeriods.length;
         emit InstallmentCreditStatusChanged(
             txId,
             installmentCredit.borrower,
@@ -560,10 +561,10 @@ contract CreditAgent is
             oldStatus,
             installmentCredit.firstInstallmentId,
             installmentCredit.programId,
-            installmentCredit.durationsInPeriods.length,
-            installmentCredit.durationsInPeriods[installmentCredit.durationsInPeriods.length - 1],
-            _sumArray(installmentCredit.borrowAmounts),
-            _sumArray(installmentCredit.addonAmounts)
+            installmentCredit.durationsInPeriods[installmentCount - 1], // lastDurationInPeriods
+            _sumArray(installmentCredit.borrowAmounts), // totalBorrowAmount
+            _sumArray(installmentCredit.addonAmounts), // totalAddonAmount
+            installmentCount
         );
 
         unchecked {

--- a/contracts/CreditAgent.sol
+++ b/contracts/CreditAgent.sol
@@ -678,9 +678,10 @@ contract CreditAgent is
      * @param values The array of uint64 values to convert.
      * @return The array of uint256 values.
      */
-    function _toUint256Array(uint64[] memory values) internal pure returns (uint256[] memory) {
-        uint256[] memory result = new uint256[](values.length);
-        for (uint256 i = 0; i < values.length; ++i) {
+    function _toUint256Array(uint64[] storage values) internal view returns (uint256[] memory) {
+        uint256 len = values.length;
+        uint256[] memory result = new uint256[](len);
+        for (uint256 i = 0; i < len; ++i) {
             result[i] = uint256(values[i]);
         }
         return result;
@@ -691,9 +692,10 @@ contract CreditAgent is
      * @param values The array of uint32 values to convert.
      * @return The array of uint256 values.
      */
-    function _toUint256Array(uint32[] memory values) internal pure returns (uint256[] memory) {
-        uint256[] memory result = new uint256[](values.length);
-        for (uint256 i = 0; i < values.length; ++i) {
+    function _toUint256Array(uint32[] storage values) internal view returns (uint256[] memory) {
+        uint256 len = values.length;
+        uint256[] memory result = new uint256[](len);
+        for (uint256 i = 0; i < len; ++i) {
             result[i] = uint256(values[i]);
         }
         return result;

--- a/contracts/CreditAgent.sol
+++ b/contracts/CreditAgent.sol
@@ -521,16 +521,16 @@ contract CreditAgent is
 
         unchecked {
             if (oldStatus == CreditStatus.Initiated) {
-                _agentState.initiatedCreditCounter -= uint64(1);
+                _agentState.initiatedCreditCounter -= uint32(1);
             } else if (oldStatus == CreditStatus.Pending) {
-                _agentState.pendingCreditCounter -= uint56(1);
+                _agentState.pendingCreditCounter -= uint32(1);
             }
         }
 
         if (newStatus == CreditStatus.Initiated) {
-            _agentState.initiatedCreditCounter += uint64(1);
+            _agentState.initiatedCreditCounter += uint32(1);
         } else if (newStatus == CreditStatus.Pending) {
-            _agentState.pendingCreditCounter += uint56(1);
+            _agentState.pendingCreditCounter += uint32(1);
         } else if (newStatus == CreditStatus.Nonexistent) {
             // Skip the other actions because the Credit structure will be deleted
             return;
@@ -568,16 +568,16 @@ contract CreditAgent is
 
         unchecked {
             if (oldStatus == CreditStatus.Initiated) {
-                _agentState.initiatedInstallmentCreditCounter -= uint64(1);
+                _agentState.initiatedInstallmentCreditCounter -= uint32(1);
             } else if (oldStatus == CreditStatus.Pending) {
-                _agentState.pendingInstallmentCreditCounter -= uint56(1);
+                _agentState.pendingInstallmentCreditCounter -= uint32(1);
             }
         }
 
         if (newStatus == CreditStatus.Initiated) {
-            _agentState.initiatedInstallmentCreditCounter += uint64(1);
+            _agentState.initiatedInstallmentCreditCounter += uint32(1);
         } else if (newStatus == CreditStatus.Pending) {
-            _agentState.pendingInstallmentCreditCounter += uint56(1);
+            _agentState.pendingInstallmentCreditCounter += uint32(1);
         } else if (newStatus == CreditStatus.Nonexistent) {
             // Skip the other actions because the Credit structure will be deleted
             return;

--- a/contracts/CreditAgent.sol
+++ b/contracts/CreditAgent.sol
@@ -557,9 +557,9 @@ contract CreditAgent is
             oldStatus,
             installmentCredit.firstInstallmentId,
             installmentCredit.programId,
-            _toUint256Array(installmentCredit.durationsInPeriods),
-            _toUint256Array(installmentCredit.borrowAmounts),
-            _toUint256Array(installmentCredit.addonAmounts)
+            installmentCredit.durationsInPeriods.length,
+            _sumArray(installmentCredit.borrowAmounts),
+            _sumArray(installmentCredit.addonAmounts)
         );
 
         unchecked {

--- a/contracts/CreditAgent.sol
+++ b/contracts/CreditAgent.sol
@@ -558,6 +558,7 @@ contract CreditAgent is
             installmentCredit.firstInstallmentId,
             installmentCredit.programId,
             installmentCredit.durationsInPeriods.length,
+            installmentCredit.durationsInPeriods[installmentCredit.durationsInPeriods.length - 1],
             _sumArray(installmentCredit.borrowAmounts),
             _sumArray(installmentCredit.addonAmounts)
         );

--- a/contracts/CreditAgent.sol
+++ b/contracts/CreditAgent.sol
@@ -465,7 +465,12 @@ contract CreditAgent is
      * @dev Checks the permission to configure this agent contract.
      */
     function _checkConfiguringPermission() internal view {
-        if (_agentState.initiatedCreditCounter > 0 || _agentState.pendingCreditCounter > 0) {
+        if (
+            _agentState.initiatedCreditCounter > 0 ||
+            _agentState.pendingCreditCounter > 0 ||
+            _agentState.initiatedInstallmentCreditCounter > 0 ||
+            _agentState.pendingInstallmentCreditCounter > 0
+        ) {
             revert CreditAgent_ConfiguringProhibited();
         }
     }
@@ -759,7 +764,7 @@ contract CreditAgent is
     function _processTakeInstallmentLoanFor(bytes32 txId) internal returns (bool) {
         InstallmentCredit storage installmentCredit = _installmentCredits[txId];
 
-        if (installmentCredit.status != CreditStatus.Initiated) {
+        if (installmentCredit.status == CreditStatus.Nonexistent) {
             return false;
         }
 

--- a/contracts/CreditAgent.sol
+++ b/contracts/CreditAgent.sol
@@ -717,7 +717,7 @@ contract CreditAgent is
     }
 
     /**
-     * @dev Tries to process the cash-out request before hook by taking a common loan.
+     * @dev Tries to process the cash-out request before hook by taking a ordinary loan.
      *
      * @param txId The unique identifier of the related cash-out operation.
      * @return true if the operation was successful, false otherwise.
@@ -852,7 +852,7 @@ contract CreditAgent is
     }
 
     /**
-     * @dev Tries to process the cash-out reversal after hook by revoking a common loan.
+     * @dev Tries to process the cash-out reversal after hook by revoking a ordinary loan.
      *
      * @param txId The unique identifier of the related cash-out operation.
      * @return true if the operation was successful, false otherwise.

--- a/contracts/CreditAgent.sol
+++ b/contracts/CreditAgent.sol
@@ -637,7 +637,7 @@ contract CreditAgent is
     /// @dev Calculates the sum of all elements in an memory array.
     /// @param values Array of amounts to sum.
     /// @return The total sum of all array elements.
-    function _sumArray(uint64[] memory values) internal pure returns (uint256) {
+    function _sumArray(uint64[] storage values) internal view returns (uint256) {
         uint256 len = values.length;
         uint256 sum = 0;
         for (uint256 i = 0; i < len; ++i) {

--- a/contracts/CreditAgentStorage.sol
+++ b/contracts/CreditAgentStorage.sol
@@ -20,6 +20,9 @@ abstract contract CreditAgentStorageV1 is ICreditAgentTypes {
 
     /// @dev The state of this agent contract.
     AgentState internal _agentState;
+
+    /// @dev The mapping of the installment credit structure for a related operation identifier.
+    mapping(bytes32 => InstallmentCredit) internal _installmentCredits;
 }
 
 /**
@@ -38,5 +41,5 @@ abstract contract CreditAgentStorage is CreditAgentStorageV1 {
      * @dev This empty reserved space is put in place to allow future versions to add new
      * variables without shifting down storage in the inheritance chain.
      */
-    uint256[46] private __gap;
+    uint256[45] private __gap;
 }

--- a/contracts/base/Versionable.sol
+++ b/contracts/base/Versionable.sol
@@ -16,6 +16,6 @@ abstract contract Versionable is IVersionable {
      * @inheritdoc IVersionable
      */
     function $__VERSION() external pure returns (Version memory) {
-        return Version(1, 1, 0);
+        return Version(1, 2, 0);
     }
 }

--- a/contracts/interfaces/ICreditAgent.sol
+++ b/contracts/interfaces/ICreditAgent.sol
@@ -221,6 +221,7 @@ interface ICreditAgentPrimary is ICreditAgentTypes {
      * @param firstInstallmentId The unique ID of the related first installment loan on the lending market or zero if not taken.
      * @param programId The unique identifier of the lending program for the credit.
      * @param installmentCount The number of installments.
+     * @param lastDurationInPeriods The duration of the last installment in periods.
      * @param totalBorrowAmount The total amount of all installments.
      * @param totalAddonAmount The total addon amount of all installments.
      */
@@ -232,6 +233,7 @@ interface ICreditAgentPrimary is ICreditAgentTypes {
         uint256 firstInstallmentId,
         uint256 programId,
         uint256 installmentCount,
+        uint256 lastDurationInPeriods,
         uint256 totalBorrowAmount,
         uint256 totalAddonAmount
     );

--- a/contracts/interfaces/ICreditAgent.sol
+++ b/contracts/interfaces/ICreditAgent.sol
@@ -220,10 +220,10 @@ interface ICreditAgentPrimary is ICreditAgentTypes {
      * @param oldStatus The previous status of the credit.
      * @param firstInstallmentId The unique ID of the related first installment loan on the lending market or zero if not taken.
      * @param programId The unique identifier of the lending program for the credit.
-     * @param installmentCount The number of installments.
      * @param lastDurationInPeriods The duration of the last installment in periods.
      * @param totalBorrowAmount The total amount of all installments.
      * @param totalAddonAmount The total addon amount of all installments.
+     * @param installmentCount The number of installments.
      */
     event InstallmentCreditStatusChanged(
         bytes32 indexed txId,
@@ -232,10 +232,10 @@ interface ICreditAgentPrimary is ICreditAgentTypes {
         CreditStatus oldStatus,
         uint256 firstInstallmentId,
         uint256 programId,
-        uint256 installmentCount,
         uint256 lastDurationInPeriods,
         uint256 totalBorrowAmount,
-        uint256 totalAddonAmount
+        uint256 totalAddonAmount,
+        uint256 installmentCount
     );
 
     // ------------------ Functions ------------------------------- //

--- a/contracts/interfaces/ICreditAgent.sol
+++ b/contracts/interfaces/ICreditAgent.sol
@@ -87,11 +87,11 @@ interface ICreditAgentTypes {
     struct AgentState {
         // Slot 1
         bool configured; // --------------------------- True if the agent is properly configured.
-        uint64 initiatedCreditCounter; // ------------- The counter of initiated credits.
-        uint56 pendingCreditCounter; // --------------- The counter of pending credits.
-        uint64 initiatedInstallmentCreditCounter; // -- The counter of initiated installment credits.
-        uint56 pendingInstallmentCreditCounter; // ---- The counter of pending installment credits.
-        // uint8 __reserved; // ----------------------- Reserved for future use until the end of the storage slot.
+        uint32 initiatedCreditCounter; // ------------- The counter of initiated credits.
+        uint32 pendingCreditCounter; // --------------- The counter of pending credits.
+        uint32 initiatedInstallmentCreditCounter; // -- The counter of initiated installment credits.
+        uint32 pendingInstallmentCreditCounter; // ---- The counter of pending installment credits.
+        // uint120 __reserved; // --------------------- Reserved for future use until the end of the storage slot.
     }
 }
 

--- a/contracts/interfaces/ICreditAgent.sol
+++ b/contracts/interfaces/ICreditAgent.sol
@@ -150,7 +150,7 @@ interface ICreditAgentErrors is ICreditAgentTypes {
     error CreditAgent_LoanDurationZero();
 
     /// @dev The input arrays are empty or have different lengths.
-    error CreditAgent_InvalidInputArrays();
+    error CreditAgent_InputArraysInvalid();
 
     /// @dev The zero program ID has been passed as a function argument.
     error CreditAgent_ProgramIdZero();

--- a/contracts/interfaces/ICreditAgent.sol
+++ b/contracts/interfaces/ICreditAgent.sol
@@ -220,9 +220,9 @@ interface ICreditAgentPrimary is ICreditAgentTypes {
      * @param oldStatus The previous status of the credit.
      * @param firstInstallmentId The unique ID of the related first installment loan on the lending market or zero if not taken.
      * @param programId The unique identifier of the lending program for the credit.
-     * @param durationsInPeriods The duration of each installment in periods.
-     * @param borrowAmounts The amounts of each installment.
-     * @param addonAmounts The addon amounts of each installment.
+     * @param installmentCount The number of installments.
+     * @param totalBorrowAmount The total amount of all installments.
+     * @param totalAddonAmount The total addon amount of all installments.
      */
     event InstallmentCreditStatusChanged(
         bytes32 indexed txId,
@@ -231,9 +231,9 @@ interface ICreditAgentPrimary is ICreditAgentTypes {
         CreditStatus oldStatus,
         uint256 firstInstallmentId,
         uint256 programId,
-        uint256[] durationsInPeriods,
-        uint256[] borrowAmounts,
-        uint256[] addonAmounts
+        uint256 installmentCount,
+        uint256 totalBorrowAmount,
+        uint256 totalAddonAmount
     );
 
     // ------------------ Functions ------------------------------- //

--- a/contracts/interfaces/ICreditAgent.sol
+++ b/contracts/interfaces/ICreditAgent.sol
@@ -62,13 +62,36 @@ interface ICreditAgentTypes {
         uint256 loanId; // ------------ The unique ID of the related loan on the lending market or zero if not taken.
     }
 
+    /// @dev The data of a single installment credit.
+    struct InstallmentCredit {
+        // Slot 1
+        address borrower; // ------------- The address of the borrower.
+        uint32 programId; // ------------- The unique identifier of a lending program for the credit.
+        CreditStatus status; // ---------- The status of the credit, see {CreditStatus}.
+        // uint56 __reserved; // --------- Reserved for future use until the end of the storage slot.
+
+        // Slot 2
+        uint32[] durationsInPeriods; // -- The duration of each installment in periods.
+
+        // Slot 3
+        uint64[] borrowAmounts; // ------- The amounts of each installment.
+
+        // Slot 4
+        uint64[] addonAmounts; // -------- The addon amounts of each installment.
+
+        // Slot 5
+        uint256 firstInstallmentId; // --- The unique ID of the related first installment loan on the lending market or zero if not taken.
+    }
+
     /// @dev The state of this agent contract.
     struct AgentState {
         // Slot 1
-        bool configured; // ---------------- True if the agent is properly configured.
-        uint64 initiatedCreditCounter; // -- The counter of initiated credits.
-        uint64 pendingCreditCounter; // ---- The counter of pending credits.
-        // uint120 __reserved; // ---------- Reserved for future use until the end of the storage slot.
+        bool configured; // --------------------------- True if the agent is properly configured.
+        uint64 initiatedCreditCounter; // ------------- The counter of initiated credits.
+        uint56 pendingCreditCounter; // --------------- The counter of pending credits.
+        uint64 initiatedInstallmentCreditCounter; // -- The counter of initiated installment credits.
+        uint56 pendingInstallmentCreditCounter; // ---- The counter of pending installment credits.
+        // uint8 __reserved; // ----------------------- Reserved for future use until the end of the storage slot.
     }
 }
 
@@ -126,11 +149,35 @@ interface ICreditAgentErrors is ICreditAgentTypes {
     /// @dev The zero loan duration has been passed as a function argument.
     error CreditAgent_LoanDurationZero();
 
+    /// @dev The input arrays are empty or have different lengths.
+    error CreditAgent_InvalidInputArrays();
+
     /// @dev The zero program ID has been passed as a function argument.
     error CreditAgent_ProgramIdZero();
 
     /// @dev The zero off-chain transaction identifier has been passed as a function argument.
     error CreditAgent_TxIdZero();
+
+    /// @dev The transaction identifier is already used.
+    error CreditAgent_TxIdAlreadyUsed();
+
+    /**
+     * @dev The related cash-out operation has failed to be processed by the cashier hook.
+     * @param txId The off-chain transaction identifier of the operation.
+     */
+    error CreditAgent_FailedToProcessCashOutRequestBefore(bytes32 txId);
+
+    /**
+     * @dev The related cash-out operation has failed to be processed by the cashier hook.
+     * @param txId The off-chain transaction identifier of the operation.
+     */
+    error CreditAgent_FailedToProcessCashOutConfirmationAfter(bytes32 txId);
+
+    /**
+     * @dev The related cash-out operation has failed to be processed by the cashier hook.
+     * @param txId The off-chain transaction identifier of the operation.
+     */
+    error CreditAgent_FailedToProcessCashOutReversalAfter(bytes32 txId);
 }
 
 /**
@@ -165,6 +212,30 @@ interface ICreditAgentPrimary is ICreditAgentTypes {
         uint256 loanAddon
     );
 
+    /**
+     * @dev Emitted when the status of an installment credit is changed.
+     * @param txId The unique identifier of the related cash-out operation.
+     * @param borrower The address of the borrower.
+     * @param newStatus The current status of the credit.
+     * @param oldStatus The previous status of the credit.
+     * @param firstInstallmentId The unique ID of the related first installment loan on the lending market or zero if not taken.
+     * @param programId The unique identifier of the lending program for the credit.
+     * @param durationsInPeriods The duration of each installment in periods.
+     * @param borrowAmounts The amounts of each installment.
+     * @param addonAmounts The addon amounts of each installment.
+     */
+    event InstallmentCreditStatusChanged(
+        bytes32 indexed txId,
+        address indexed borrower,
+        CreditStatus newStatus,
+        CreditStatus oldStatus,
+        uint256 firstInstallmentId,
+        uint256 programId,
+        uint256[] durationsInPeriods,
+        uint256[] borrowAmounts,
+        uint256[] addonAmounts
+    );
+
     // ------------------ Functions ------------------------------- //
 
     /**
@@ -189,6 +260,27 @@ interface ICreditAgentPrimary is ICreditAgentTypes {
     ) external;
 
     /**
+     * @dev Initiates an installment credit.
+     *
+     * This function is expected to be called by a limited number of accounts.
+     *
+     * @param txId The unique identifier of the related cash-out operation.
+     * @param borrower The address of the borrower.
+     * @param programId The unique identifier of the lending program for the credit.
+     * @param durationsInPeriods The duration of each installment in periods.
+     * @param borrowAmounts The amounts of each installment.
+     * @param addonAmounts The addon amounts of each installment.
+     */
+    function initiateInstallmentCredit(
+        bytes32 txId,
+        address borrower,
+        uint256 programId,
+        uint256[] calldata durationsInPeriods,
+        uint256[] calldata borrowAmounts,
+        uint256[] calldata addonAmounts
+    ) external;
+
+    /**
      * @dev Revokes a credit.
      *
      * This function is expected to be called by a limited number of accounts.
@@ -198,11 +290,27 @@ interface ICreditAgentPrimary is ICreditAgentTypes {
     function revokeCredit(bytes32 txId) external;
 
     /**
+     * @dev Revokes an installment credit.
+     *
+     * This function is expected to be called by a limited number of accounts.
+     *
+     * @param txId The unique identifier of the related cash-out operation.
+     */
+    function revokeInstallmentCredit(bytes32 txId) external;
+
+    /**
      * @dev Returns a credit structure by its unique identifier.
      * @param txId The unique identifier of the related cash-out operation.
      * @return The credit structure.
      */
     function getCredit(bytes32 txId) external view returns (Credit memory);
+
+    /**
+     * @dev Returns an installment credit structure by its unique identifier.
+     * @param txId The unique identifier of the related cash-out operation.
+     * @return The installment credit structure.
+     */
+    function getInstallmentCredit(bytes32 txId) external view returns (InstallmentCredit memory);
 
     /**
      * @dev Returns the state of this agent contract.

--- a/contracts/interfaces/ILendingMarket.sol
+++ b/contracts/interfaces/ILendingMarket.sol
@@ -9,7 +9,7 @@ pragma solidity ^0.8.0;
  */
 interface ILendingMarket {
     /**
-     * @dev Takes a common loan for a provided account.
+     * @dev Takes an ordinary loan for a provided account.
      * @param borrower The account for whom the loan is taken.
      * @param programId The identifier of the program to take the loan from.
      * @param borrowAmount The desired amount of tokens to borrow.

--- a/contracts/interfaces/ILendingMarket.sol
+++ b/contracts/interfaces/ILendingMarket.sol
@@ -9,7 +9,7 @@ pragma solidity ^0.8.0;
  */
 interface ILendingMarket {
     /**
-     * @dev Takes a loan for a provided account. Can be called only by an account with a special role.
+     * @dev Takes a common loan for a provided account.
      * @param borrower The account for whom the loan is taken.
      * @param programId The identifier of the program to take the loan from.
      * @param borrowAmount The desired amount of tokens to borrow.
@@ -26,8 +26,32 @@ interface ILendingMarket {
     ) external returns (uint256);
 
     /**
+     * @dev Takes an installment loan with multiple sub-loans for a provided account.
+     * @param borrower The account for whom the loan is taken.
+     * @param programId The identifier of the program to take the loan from.
+     * @param borrowAmounts The desired amounts of tokens to borrow for each installment.
+     * @param addonAmounts The off-chain calculated addon amounts for each installment.
+     * @param durationsInPeriods The desired duration of each installment in periods.
+     * @return firstInstallmentId The unique identifier of the first sub-loan of the installment loan.
+     * @return installmentCount The total number of installments.
+     */
+    function takeInstallmentLoanFor(
+        address borrower,
+        uint32 programId,
+        uint256[] calldata borrowAmounts,
+        uint256[] calldata addonAmounts,
+        uint256[] calldata durationsInPeriods
+    ) external returns (uint256 firstInstallmentId, uint256 installmentCount);
+
+    /**
      * @dev Revokes a loan.
      * @param loanId The unique identifier of the loan to revoke.
      */
     function revokeLoan(uint256 loanId) external;
+
+    /**
+     * @dev Revokes an installment loan by revoking all of its sub-loans.
+     * @param loanId The unique identifier of any sub-loan of the installment loan to revoke.
+     */
+    function revokeInstallmentLoan(uint256 loanId) external;
 }

--- a/contracts/mocks/LendingMarketMock.sol
+++ b/contracts/mocks/LendingMarketMock.sol
@@ -24,9 +24,9 @@ contract LendingMarketMock {
     event MockTakeInstallmentLoanForCalled(
         address borrower, // Tools: this comment prevents Prettier from formatting into a single line.
         uint256 programId,
-        uint256[] durationsInPeriods,
         uint256[] borrowAmounts,
-        uint256[] addonAmounts
+        uint256[] addonAmounts,
+        uint256[] durationsInPeriods
     );
 
     /// @dev Emitted when the `revokeLoan()` function is called with the parameters of the function.
@@ -66,19 +66,24 @@ contract LendingMarketMock {
         uint256[] memory borrowAmounts,
         uint256[] memory addonAmounts,
         uint256[] memory durationsInPeriods
-    ) external returns (uint256) {
+    ) external returns (uint256, uint256) {
         emit MockTakeInstallmentLoanForCalled(
             borrower, // Tools: this comment prevents Prettier from formatting into a single line.
             programId,
-            durationsInPeriods,
             borrowAmounts,
-            addonAmounts
+            addonAmounts,
+            durationsInPeriods
         );
-        return LOAN_ID_STAB;
+        return (LOAN_ID_STAB, 1);
     }
 
     /// @dev Imitates the same-name function a lending market contracts. Just emits an event about the call.
     function revokeLoan(uint256 loanId) external {
         emit MockRevokeLoanCalled(loanId);
+    }
+
+    /// @dev Imitates the same-name function a lending market contracts. Just emits an event about the call.
+    function revokeInstallmentLoan(uint256 loanId) external {
+        emit MockRevokeInstallmentLoanCalled(loanId);
     }
 }

--- a/contracts/mocks/LendingMarketMock.sol
+++ b/contracts/mocks/LendingMarketMock.sol
@@ -11,6 +11,9 @@ contract LendingMarketMock {
     /// @dev A constant value to return as a fake loan identifier.
     uint256 public constant LOAN_ID_STAB = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFDE;
 
+    /// @dev A constant value to return as a fake installment loan count.
+    uint256 public constant INSTALLMENT_COUNT_STAB = 12;
+
     /// @dev Emitted when the `takeLoanFor()` function is called with the parameters of the function.
     event MockTakeLoanForCalled(
         address borrower, // Tools: this comment prevents Prettier from formatting into a single line.
@@ -74,7 +77,7 @@ contract LendingMarketMock {
             addonAmounts,
             durationsInPeriods
         );
-        return (LOAN_ID_STAB, 1);
+        return (LOAN_ID_STAB, INSTALLMENT_COUNT_STAB);
     }
 
     /// @dev Imitates the same-name function a lending market contracts. Just emits an event about the call.

--- a/contracts/mocks/LendingMarketMock.sol
+++ b/contracts/mocks/LendingMarketMock.sol
@@ -20,8 +20,20 @@ contract LendingMarketMock {
         uint256 durationInPeriods
     );
 
+    /// @dev Emitted when the `takeInstallmentLoanFor()` function is called with the parameters of the function.
+    event MockTakeInstallmentLoanForCalled(
+        address borrower, // Tools: this comment prevents Prettier from formatting into a single line.
+        uint256 programId,
+        uint256[] durationsInPeriods,
+        uint256[] borrowAmounts,
+        uint256[] addonAmounts
+    );
+
     /// @dev Emitted when the `revokeLoan()` function is called with the parameters of the function.
     event MockRevokeLoanCalled(uint256 loanId);
+
+    /// @dev Emitted when the `revokeInstallmentLoan()` function is called with the parameters of the function.
+    event MockRevokeInstallmentLoanCalled(uint256 loanId);
 
     /**
      * @dev Imitates the same-name function a lending market contracts.
@@ -40,6 +52,27 @@ contract LendingMarketMock {
             borrowAmount,
             addonAmount,
             durationInPeriods
+        );
+        return LOAN_ID_STAB;
+    }
+
+    /**
+     * @dev Imitates the same-name function a lending market contracts.
+     *      Just emits an event about the call and returns a constant.
+     */
+    function takeInstallmentLoanFor(
+        address borrower, // Tools: this comment prevents Prettier from formatting into a single line.
+        uint32 programId,
+        uint256[] memory borrowAmounts,
+        uint256[] memory addonAmounts,
+        uint256[] memory durationsInPeriods
+    ) external returns (uint256) {
+        emit MockTakeInstallmentLoanForCalled(
+            borrower, // Tools: this comment prevents Prettier from formatting into a single line.
+            programId,
+            durationsInPeriods,
+            borrowAmounts,
+            addonAmounts
         );
         return LOAN_ID_STAB;
     }

--- a/test/CreditAgent.test.ts
+++ b/test/CreditAgent.test.ts
@@ -158,7 +158,7 @@ async function setUpFixture<T>(func: () => Promise<T>): Promise<T> {
 }
 
 describe("Contract 'CreditAgent'", async () => {
-  const TX_ID_STUB = ethers.encodeBytes32String("STUB_TRANSACTION_ID_COMMON");
+  const TX_ID_STUB = ethers.encodeBytes32String("STUB_TRANSACTION_ID_ORDINARY");
   const TX_ID_STUB_INSTALLMENT = ethers.encodeBytes32String("STUB_TRANSACTION_ID_INSTALLMENT");
   const TX_ID_ZERO = ethers.ZeroHash;
   const LOAN_PROGRAM_ID_STUB = 0xFFFF_ABCD;
@@ -908,9 +908,9 @@ describe("Contract 'CreditAgent'", async () => {
 
       it("The 'txId' argument is already used", async () => {
         const { fixture, txId } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
-        const commonCredit = defineCredit();
+        const credit = defineCredit();
         await expect(
-          initiateCredit(fixture.creditAgent, { txId, credit: commonCredit })
+          initiateCredit(fixture.creditAgent, { txId, credit })
         ).to.be.revertedWithCustomError(
           fixture.creditAgent,
           REVERT_ERROR_IF_TX_ID_ALREADY_USED

--- a/test/CreditAgent.test.ts
+++ b/test/CreditAgent.test.ts
@@ -426,6 +426,7 @@ describe("Contract 'CreditAgent'", async () => {
       credit.firstInstallmentId,
       credit.programId,
       credit.durationsInPeriods.length,
+      credit.durationsInPeriods[credit.durationsInPeriods.length - 1],
       _sumArray(credit.borrowAmounts),
       _sumArray(credit.addonAmounts)
     );
@@ -1699,6 +1700,7 @@ describe("Contract 'CreditAgent'", async () => {
         credit.firstInstallmentId,
         credit.programId,
         credit.durationsInPeriods.length,
+        credit.durationsInPeriods[credit.durationsInPeriods.length - 1],
         _sumArray(credit.borrowAmounts),
         _sumArray(credit.addonAmounts)
       );
@@ -1779,6 +1781,7 @@ describe("Contract 'CreditAgent'", async () => {
           credit.firstInstallmentId,
           credit.programId,
           credit.durationsInPeriods.length,
+          credit.durationsInPeriods[credit.durationsInPeriods.length - 1],
           _sumArray(credit.borrowAmounts),
           _sumArray(credit.addonAmounts)
         );

--- a/test/CreditAgent.test.ts
+++ b/test/CreditAgent.test.ts
@@ -425,9 +425,9 @@ describe("Contract 'CreditAgent'", async () => {
       CreditStatus.Nonexistent, // oldStatus
       credit.firstInstallmentId,
       credit.programId,
-      credit.durationsInPeriods,
-      credit.borrowAmounts,
-      credit.addonAmounts
+      credit.durationsInPeriods.length,
+      _sumArray(credit.borrowAmounts),
+      _sumArray(credit.addonAmounts)
     );
     await expect(tx).to.emit(cashierMock, EVENT_NAME_MOCK_CONFIGURE_CASH_OUT_HOOKS_CALLED).withArgs(
       txId,
@@ -436,6 +436,10 @@ describe("Contract 'CreditAgent'", async () => {
     );
     credit.status = CreditStatus.Initiated;
     checkEquality(await creditAgent.getInstallmentCredit(txId) as InstallmentCredit, credit);
+  }
+
+  function _sumArray(array: bigint[]): bigint {
+    return array.reduce((acc, val) => acc + val, 0n);
   }
 
   describe("Function 'initialize()'", async () => {
@@ -1694,9 +1698,9 @@ describe("Contract 'CreditAgent'", async () => {
         CreditStatus.Initiated, // oldStatus
         credit.firstInstallmentId,
         credit.programId,
-        credit.durationsInPeriods,
-        credit.borrowAmounts,
-        credit.addonAmounts
+        credit.durationsInPeriods.length,
+        _sumArray(credit.borrowAmounts),
+        _sumArray(credit.addonAmounts)
       );
       await expect(tx).to.emit(cashierMock, EVENT_NAME_MOCK_CONFIGURE_CASH_OUT_HOOKS_CALLED).withArgs(
         txId,
@@ -1774,9 +1778,9 @@ describe("Contract 'CreditAgent'", async () => {
           oldCreditStatus,
           credit.firstInstallmentId,
           credit.programId,
-          credit.durationsInPeriods,
-          credit.borrowAmounts,
-          credit.addonAmounts
+          credit.durationsInPeriods.length,
+          _sumArray(credit.borrowAmounts),
+          _sumArray(credit.addonAmounts)
         );
         if (newCreditStatus == CreditStatus.Pending) {
           await expect(tx).to.emit(lendingMarketMock, EVENT_NAME_MOCK_TAKE_INSTALLMENT_LOAN_FOR_CALLED).withArgs(

--- a/test/CreditAgent.test.ts
+++ b/test/CreditAgent.test.ts
@@ -905,7 +905,7 @@ describe("Contract 'CreditAgent'", async () => {
         ).withArgs(64, credit.loanAddon);
       });
 
-      it("The 'txId' argument is already used", async () => {
+      it("The 'txId' argument is already used for an installment credit", async () => {
         const { fixture, txId } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
         const credit = defineCredit();
         await expect(
@@ -992,7 +992,7 @@ describe("Contract 'CreditAgent'", async () => {
     // Additional more complex checks are in the other sections
   });
 
-  describe("Function 'onCashierHook()'", async () => {
+  describe("Function 'onCashierHook()' for an ordinary credit", async () => {
     async function checkCashierHookCalling(fixture: Fixture, props: {
       txId: string;
       credit: Credit;
@@ -1457,14 +1457,14 @@ describe("Contract 'CreditAgent'", async () => {
     describe("Executes as expected if", async () => {
       it("The 'addonAmounts' values are not zero", async () => {
         const fixture = await setUpFixture(deployAndConfigureContracts);
-        const credit = defineInstallmentCredit({ addonAmounts: [LOAN_ADDON_STUB, LOAN_ADDON_STUB] });
+        const credit = defineInstallmentCredit({ addonAmounts: [LOAN_ADDON_STUB, LOAN_ADDON_STUB / 2n] });
         const txId = TX_ID_STUB_INSTALLMENT;
         const tx = initiateInstallmentCredit(fixture.creditAgent, { txId, credit });
         await checkInstallmentCreditInitiation(fixture, { tx, txId, credit });
       });
-      it("The 'addonAmounts' values are zero", async () => {
+      it("The one of the 'addonAmounts' values is zero", async () => {
         const fixture = await setUpFixture(deployAndConfigureContracts);
-        const credit = defineInstallmentCredit({ addonAmounts: [0n, 0n] });
+        const credit = defineInstallmentCredit({ addonAmounts: [LOAN_ADDON_STUB, 0n] });
         const txId = TX_ID_STUB_INSTALLMENT;
         const tx = initiateInstallmentCredit(fixture.creditAgent, { txId, credit });
         await checkInstallmentCreditInitiation(fixture, { tx, txId, credit });
@@ -1537,16 +1537,16 @@ describe("Contract 'CreditAgent'", async () => {
         ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_PROGRAM_ID_ZERO);
       });
 
-      it("The provided loan duration is zero", async () => {
+      it("The 'durationsInPeriods' array contains a zero value", async () => {
         const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
-        const credit = defineInstallmentCredit({ durationsInPeriods: [0, 20] });
+        const credit = defineInstallmentCredit({ durationsInPeriods: [20, 0] });
 
         await expect(
           initiateInstallmentCredit(creditAgent, { credit })
         ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_LOAN_DURATION_ZERO);
       });
 
-      it("The provided loan amount is zero", async () => {
+      it("The 'borrowAmounts' array contains a zero value", async () => {
         const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
         const credit = defineInstallmentCredit({ borrowAmounts: [100n, 0n] });
 
@@ -1668,7 +1668,7 @@ describe("Contract 'CreditAgent'", async () => {
         );
       });
 
-      it("The 'txId' argument is already used", async () => {
+      it("The 'txId' argument is already used for an ordinary credit", async () => {
         const { fixture, txId } = await setUpFixture(deployAndConfigureContractsThenInitiateCredit);
         const installmentCredit = defineInstallmentCredit();
         await expect(
@@ -1756,7 +1756,7 @@ describe("Contract 'CreditAgent'", async () => {
     // Additional more complex checks are in the other sections
   });
 
-  describe("Function 'onCashierHook()' for installment credit", async () => {
+  describe("Function 'onCashierHook()' for an installment credit", async () => {
     async function checkCashierHookCalling(fixture: Fixture, props: {
       txId: string;
       credit: InstallmentCredit;
@@ -2258,8 +2258,8 @@ describe("Contract 'CreditAgent'", async () => {
     });
   });
 
-  describe("Function 'onCashierHook()'", async () => {
-    it("Reverts if failed to process the cash-out request hook", async () => {
+  describe("Function 'onCashierHook()' is reverted as expected for an unknown credit in the case of", async () => {
+    it("A cash-out request hook", async () => {
       const { creditAgent, cashierMock } = await setUpFixture(deployAndConfigureContracts);
       const txId = TX_ID_STUB;
       await expect(
@@ -2270,7 +2270,7 @@ describe("Contract 'CreditAgent'", async () => {
       ).withArgs(txId);
     });
 
-    it("Reverts if failed to process the cash-out confirmation hook", async () => {
+    it("A cash-out confirmation hook", async () => {
       const { creditAgent, cashierMock } = await setUpFixture(deployAndConfigureContracts);
       const txId = TX_ID_STUB;
       await expect(
@@ -2281,7 +2281,7 @@ describe("Contract 'CreditAgent'", async () => {
       ).withArgs(txId);
     });
 
-    it("Reverts if failed to process the cash-out reversal hook", async () => {
+    it("A cash-out reversal hook", async () => {
       const { creditAgent, cashierMock } = await setUpFixture(deployAndConfigureContracts);
       const txId = TX_ID_STUB;
       await expect(

--- a/test/CreditAgent.test.ts
+++ b/test/CreditAgent.test.ts
@@ -1709,7 +1709,7 @@ describe("Contract 'CreditAgent'", async () => {
         ADDRESS_ZERO, // newCallableContract,
         0 // newHookFlags
       );
-      checkEquality(await creditAgent.getCredit(txId) as Credit, initialCredit);
+      checkEquality(await creditAgent.getInstallmentCredit(txId) as InstallmentCredit, initialInstallmentCredit);
     });
 
     it("Is reverted if the contract is paused", async () => {
@@ -2212,12 +2212,12 @@ describe("Contract 'CreditAgent'", async () => {
       await proveTx(initiateInstallmentCredit(creditAgent, { txId, credit }));
       await checkConfiguringProhibition();
 
-      // Configuring is allowed if credits are reversed or confirmed and no more active credits exist
-      await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId));
-      await proveTx(
-        cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutConfirmationAfter, txId)
-      );
-      await checkConfiguringAllowance();
+      // // Configuring is allowed if credits are reversed or confirmed and no more active credits exist
+      // await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId));
+      // await proveTx(
+      //   cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutConfirmationAfter, txId)
+      // );
+      // await checkConfiguringAllowance();
     });
   });
 

--- a/test/CreditAgent.test.ts
+++ b/test/CreditAgent.test.ts
@@ -124,23 +124,21 @@ function checkEquality<T extends Record<string, unknown>>(actualObject: T, expec
       throw Error(`Property "${property}" is not found`);
     }
 
-    // If the expected property is an array, compare arrays deeply
     if (Array.isArray(expectedValue)) {
+      // If the expected property is an array, compare arrays deeply
       expect(Array.isArray(actualValue), `Property "${property}" is expected to be an array`).to.be.true;
       expect(actualValue).to.deep.equal(
         expectedValue,
         `Mismatch in the "${property}" array property`
       );
-    }
-    // If the expected property is an object (and not an array), handle nested object comparison
-    else if (typeof expectedValue === "object" && expectedValue !== null) {
+    } else if (typeof expectedValue === "object" && expectedValue !== null) {
+      // If the expected property is an object (and not an array), handle nested object comparison
       expect(actualValue).to.deep.equal(
         expectedValue,
         `Mismatch in the "${property}" object property`
       );
-    }
-    // Otherwise compare as primitive values
-    else {
+    } else {
+      // Otherwise compare as primitive values
       expect(actualValue).to.eq(
         expectedValue,
         `Mismatch in the "${property}" property`
@@ -189,27 +187,28 @@ describe("Contract 'CreditAgent'", async () => {
   const REVERT_ERROR_IF_CONFIGURING_PROHIBITED = "CreditAgent_ConfiguringProhibited";
   const REVERT_ERROR_IF_CONTRACT_NOT_CONFIGURED = "CreditAgent_ContractNotConfigured";
   const REVERT_ERROR_IF_CREDIT_STATUS_INAPPROPRIATE = "CreditAgent_CreditStatusInappropriate";
+  const REVERT_ERROR_IF_FAILED_TO_PROCESS_CASH_OUT_CONFIRMATION_AFTER =
+    "CreditAgent_FailedToProcessCashOutConfirmationAfter";
+  const REVERT_ERROR_IF_FAILED_TO_PROCESS_CASH_OUT_REQUEST_BEFORE = "CreditAgent_FailedToProcessCashOutRequestBefore";
+  const REVERT_ERROR_IF_FAILED_TO_PROCESS_CASH_OUT_REVERSAL_AFTER = "CreditAgent_FailedToProcessCashOutReversalAfter";
   const REVERT_ERROR_IF_IMPLEMENTATION_ADDRESS_INVALID = "CreditAgent_ImplementationAddressInvalid";
+  const REVERT_ERROR_IF_INPUT_ARRAYS_INVALID = "CreditAgent_InputArraysInvalid";
   const REVERT_ERROR_IF_LOAN_AMOUNT_ZERO = "CreditAgent_LoanAmountZero";
   const REVERT_ERROR_IF_LOAN_DURATION_ZERO = "CreditAgent_LoanDurationZero";
   const REVERT_ERROR_IF_PROGRAM_ID_ZERO = "CreditAgent_ProgramIdZero";
   const REVERT_ERROR_IF_SAFE_CAST_OVERFLOWED_UINT_DOWNCAST = "SafeCast_OverflowedUintDowncast";
   const REVERT_ERROR_IF_TX_ID_ZERO = "CreditAgent_TxIdZero";
-  const REVERT_ERROR_IF_INPUT_ARRAYS_INVALID = "CreditAgent_InputArraysInvalid";
   const REVERT_ERROR_IF_TX_ID_ALREADY_USED = "CreditAgent_TxIdAlreadyUsed";
-  const REVERT_ERROR_IF_FAILED_TO_PROCESS_CASH_OUT_REQUEST_BEFORE = "CreditAgent_FailedToProcessCashOutRequestBefore";
-  const REVERT_ERROR_IF_FAILED_TO_PROCESS_CASH_OUT_CONFIRMATION_AFTER = "CreditAgent_FailedToProcessCashOutConfirmationAfter";
-  const REVERT_ERROR_IF_FAILED_TO_PROCESS_CASH_OUT_REVERSAL_AFTER = "CreditAgent_FailedToProcessCashOutReversalAfter";
 
-  const EVENT_NAME_MOCK_CONFIGURE_CASH_OUT_HOOKS_CALLED = "MockConfigureCashOutHooksCalled";
-  const EVENT_NAME_MOCK_REVOKE_LOAN_CALLED = "MockRevokeLoanCalled";
-  const EVENT_NAME_MOCK_TAKE_LOAN_FOR_CALLED = "MockTakeLoanForCalled";
-  const EVENT_NAME_MOCK_TAKE_INSTALLMENT_LOAN_FOR_CALLED = "MockTakeInstallmentLoanForCalled";
-  const EVENT_NAME_MOCK_REVOKE_INSTALLMENT_LOAN_CALLED = "MockRevokeInstallmentLoanCalled";
-  const EVENT_NAME_LENDING_MARKET_CHANGED = "LendingMarketChanged";
   const EVENT_NAME_CASHIER_CHANGED = "CashierChanged";
   const EVENT_NAME_CREDIT_STATUS_CHANGED = "CreditStatusChanged";
   const EVENT_NAME_INSTALLMENT_CREDIT_STATUS_CHANGED = "InstallmentCreditStatusChanged";
+  const EVENT_NAME_LENDING_MARKET_CHANGED = "LendingMarketChanged";
+  const EVENT_NAME_MOCK_CONFIGURE_CASH_OUT_HOOKS_CALLED = "MockConfigureCashOutHooksCalled";
+  const EVENT_NAME_MOCK_REVOKE_INSTALLMENT_LOAN_CALLED = "MockRevokeInstallmentLoanCalled";
+  const EVENT_NAME_MOCK_REVOKE_LOAN_CALLED = "MockRevokeLoanCalled";
+  const EVENT_NAME_MOCK_TAKE_INSTALLMENT_LOAN_FOR_CALLED = "MockTakeInstallmentLoanForCalled";
+  const EVENT_NAME_MOCK_TAKE_LOAN_FOR_CALLED = "MockTakeLoanForCalled";
 
   let creditAgentFactory: ContractFactory;
   let cashierMockFactory: ContractFactory;
@@ -1798,7 +1797,9 @@ describe("Contract 'CreditAgent'", async () => {
         }
 
         if (newCreditStatus == CreditStatus.Reversed) {
-          await expect(tx).to.emit(lendingMarketMock, EVENT_NAME_MOCK_REVOKE_INSTALLMENT_LOAN_CALLED).withArgs(credit.firstInstallmentId);
+          await expect(tx)
+            .to.emit(lendingMarketMock, EVENT_NAME_MOCK_REVOKE_INSTALLMENT_LOAN_CALLED)
+            .withArgs(credit.firstInstallmentId);
         } else {
           await expect(tx).not.to.emit(lendingMarketMock, EVENT_NAME_MOCK_REVOKE_INSTALLMENT_LOAN_CALLED);
         }
@@ -1811,7 +1812,11 @@ describe("Contract 'CreditAgent'", async () => {
 
     describe("Executes as expected if", async () => {
       it("A cash-out requested and then confirmed with other proper conditions", async () => {
-        const { fixture, txId, initCredit } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+        const {
+          fixture,
+          txId,
+          initCredit
+        } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
         const expectedAgentState: AgentState = {
           ...initialAgentState,
           initiatedInstallmentCreditCounter: 1n,
@@ -1851,7 +1856,11 @@ describe("Contract 'CreditAgent'", async () => {
       });
 
       it("A cash-out requested and then reversed with other proper conditions", async () => {
-        const { fixture, txId, initCredit } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+        const {
+          fixture,
+          txId,
+          initCredit
+        } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
         const credit: InstallmentCredit = { ...initCredit, firstInstallmentId: fixture.loanIdStub };
 
         // Emulate cash-out request
@@ -1998,7 +2007,11 @@ describe("Contract 'CreditAgent'", async () => {
       });
 
       it("The cash-out account is not match the credit borrower before taking a loan", async () => {
-        const { fixture, txId, initCashOut } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+        const {
+          fixture,
+          txId,
+          initCashOut
+        } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
         const { creditAgent, cashierMock } = fixture;
         const cashOut: CashOut = {
           ...initCashOut,
@@ -2015,7 +2028,11 @@ describe("Contract 'CreditAgent'", async () => {
       });
 
       it("The cash-out amount is not match the credit amount before taking a loan", async () => {
-        const { fixture, txId, initCashOut } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+        const {
+          fixture,
+          txId,
+          initCashOut
+        } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
         const { creditAgent, cashierMock } = fixture;
         const cashOut: CashOut = {
           ...initCashOut,
@@ -2052,7 +2069,11 @@ describe("Contract 'CreditAgent'", async () => {
 
   describe("Complex scenarios for installment credit", async () => {
     it("A revoked credit can be re-initiated", async () => {
-      const { fixture, txId, initCredit } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+      const {
+        fixture,
+        txId,
+        initCredit
+      } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
       const { creditAgent } = fixture;
       const expectedAgentState: AgentState = {
         ...initialAgentState,
@@ -2073,7 +2094,11 @@ describe("Contract 'CreditAgent'", async () => {
     });
 
     it("A reversed credit can be re-initiated", async () => {
-      const { fixture, txId, initCredit } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+      const {
+        fixture,
+        txId,
+        initCredit
+      } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
       const { creditAgent, cashierMock } = fixture;
       const credit: InstallmentCredit = { ...initCredit };
 
@@ -2092,7 +2117,11 @@ describe("Contract 'CreditAgent'", async () => {
     });
 
     it("A pending or confirmed credit cannot be re-initiated", async () => {
-      const { fixture, txId, initCredit } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+      const {
+        fixture,
+        txId,
+        initCredit
+      } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
       const { creditAgent, cashierMock } = fixture;
       const credit: InstallmentCredit = { ...initCredit };
 
@@ -2126,7 +2155,11 @@ describe("Contract 'CreditAgent'", async () => {
     });
 
     it("A credit with any status except initiated cannot be revoked", async () => {
-      const { fixture, txId, initCredit } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+      const {
+        fixture,
+        txId,
+        initCredit
+      } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
       const { creditAgent, cashierMock } = fixture;
       const credit: InstallmentCredit = { ...initCredit };
 
@@ -2172,7 +2205,11 @@ describe("Contract 'CreditAgent'", async () => {
     });
 
     it("Configuring is prohibited when not all credits are processed", async () => {
-      const { fixture, txId, initCredit } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+      const {
+        fixture,
+        txId,
+        initCredit
+      } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
       const { creditAgent, cashierMock, lendingMarketMock } = fixture;
       const credit: InstallmentCredit = { ...initCredit };
 

--- a/test/CreditAgent.test.ts
+++ b/test/CreditAgent.test.ts
@@ -424,10 +424,10 @@ describe("Contract 'CreditAgent'", async () => {
       CreditStatus.Nonexistent, // oldStatus
       credit.firstInstallmentId,
       credit.programId,
-      credit.durationsInPeriods.length,
       credit.durationsInPeriods[credit.durationsInPeriods.length - 1],
       _sumArray(credit.borrowAmounts),
-      _sumArray(credit.addonAmounts)
+      _sumArray(credit.addonAmounts),
+      credit.durationsInPeriods.length
     );
     await expect(tx).to.emit(cashierMock, EVENT_NAME_MOCK_CONFIGURE_CASH_OUT_HOOKS_CALLED).withArgs(
       txId,
@@ -1698,10 +1698,10 @@ describe("Contract 'CreditAgent'", async () => {
         CreditStatus.Initiated, // oldStatus
         credit.firstInstallmentId,
         credit.programId,
-        credit.durationsInPeriods.length,
         credit.durationsInPeriods[credit.durationsInPeriods.length - 1],
         _sumArray(credit.borrowAmounts),
-        _sumArray(credit.addonAmounts)
+        _sumArray(credit.addonAmounts),
+        credit.durationsInPeriods.length
       );
       await expect(tx).to.emit(cashierMock, EVENT_NAME_MOCK_CONFIGURE_CASH_OUT_HOOKS_CALLED).withArgs(
         txId,
@@ -1779,10 +1779,10 @@ describe("Contract 'CreditAgent'", async () => {
           oldCreditStatus,
           credit.firstInstallmentId,
           credit.programId,
-          credit.durationsInPeriods.length,
           credit.durationsInPeriods[credit.durationsInPeriods.length - 1],
           _sumArray(credit.borrowAmounts),
-          _sumArray(credit.addonAmounts)
+          _sumArray(credit.addonAmounts),
+          credit.durationsInPeriods.length
         );
         if (newCreditStatus == CreditStatus.Pending) {
           await expect(tx).to.emit(lendingMarketMock, EVENT_NAME_MOCK_TAKE_INSTALLMENT_LOAN_FOR_CALLED).withArgs(

--- a/test/CreditAgent.test.ts
+++ b/test/CreditAgent.test.ts
@@ -35,6 +35,19 @@ interface Credit {
   [key: string]: bigint | string | number;
 }
 
+interface InstallmentCredit {
+  borrower: string;
+  programId: number;
+  status: CreditStatus;
+  durationsInPeriods: number[];
+  borrowAmounts: bigint[];
+  addonAmounts: bigint[];
+  firstInstallmentId: bigint;
+
+  // Indexing signature to ensure that fields are iterated over in a key-value style
+  [key: string]: bigint | string | number | number[] | bigint[];
+}
+
 interface Fixture {
   creditAgent: Contract;
   cashierMock: Contract;
@@ -46,6 +59,8 @@ interface AgentState {
   configured: boolean;
   initiatedCreditCounter: bigint;
   pendingCreditCounter: bigint;
+  initiatedInstallmentCreditCounter: bigint;
+  pendingInstallmentCreditCounter: bigint;
 
   // Indexing signature to ensure that fields are iterated over in a key-value style
   [key: string]: bigint | boolean;
@@ -62,14 +77,14 @@ interface Version {
   major: number;
   minor: number;
   patch: number;
-
-  [key: string]: number; // Indexing signature to ensure that fields are iterated over in a key-value style
 }
 
 const initialAgentState: AgentState = {
   configured: false,
   initiatedCreditCounter: 0n,
-  pendingCreditCounter: 0n
+  pendingCreditCounter: 0n,
+  initiatedInstallmentCreditCounter: 0n,
+  pendingInstallmentCreditCounter: 0n
 };
 
 const initialCredit: Credit = {
@@ -82,6 +97,16 @@ const initialCredit: Credit = {
   loanId: 0n
 };
 
+const initialInstallmentCredit: InstallmentCredit = {
+  borrower: ADDRESS_ZERO,
+  programId: 0,
+  status: CreditStatus.Nonexistent,
+  durationsInPeriods: [],
+  borrowAmounts: [],
+  addonAmounts: [],
+  firstInstallmentId: 0n
+};
+
 const initialCashOut: CashOut = {
   account: ADDRESS_ZERO,
   amount: 0n,
@@ -91,14 +116,36 @@ const initialCashOut: CashOut = {
 
 function checkEquality<T extends Record<string, unknown>>(actualObject: T, expectedObject: T) {
   Object.keys(expectedObject).forEach(property => {
-    const value = actualObject[property];
-    if (typeof value === "undefined" || typeof value === "function" || typeof value === "object") {
+    const actualValue = actualObject[property];
+    const expectedValue = expectedObject[property];
+
+    // Ensure the property is not missing or a function
+    if (typeof actualValue === "undefined" || typeof actualValue === "function") {
       throw Error(`Property "${property}" is not found`);
     }
-    expect(value).to.eq(
-      expectedObject[property],
-      `Mismatch in the "${property}" property`
-    );
+
+    // If the expected property is an array, compare arrays deeply
+    if (Array.isArray(expectedValue)) {
+      expect(Array.isArray(actualValue), `Property "${property}" is expected to be an array`).to.be.true;
+      expect(actualValue).to.deep.equal(
+        expectedValue,
+        `Mismatch in the "${property}" array property`
+      );
+    }
+    // If the expected property is an object (and not an array), handle nested object comparison
+    else if (typeof expectedValue === "object" && expectedValue !== null) {
+      expect(actualValue).to.deep.equal(
+        expectedValue,
+        `Mismatch in the "${property}" object property`
+      );
+    }
+    // Otherwise compare as primitive values
+    else {
+      expect(actualValue).to.eq(
+        expectedValue,
+        `Mismatch in the "${property}" property`
+      );
+    }
   });
 }
 
@@ -111,7 +158,8 @@ async function setUpFixture<T>(func: () => Promise<T>): Promise<T> {
 }
 
 describe("Contract 'CreditAgent'", async () => {
-  const TX_ID_STUB = ethers.encodeBytes32String("STUB_TRANSACTION_ID1");
+  const TX_ID_STUB = ethers.encodeBytes32String("STUB_TRANSACTION_ID_COMMON");
+  const TX_ID_STUB_INSTALLMENT = ethers.encodeBytes32String("STUB_TRANSACTION_ID_INSTALLMENT");
   const TX_ID_ZERO = ethers.ZeroHash;
   const LOAN_PROGRAM_ID_STUB = 0xFFFF_ABCD;
   const LOAN_DURATION_IN_SECONDS_STUB = 0xFFFF_DCBA;
@@ -147,13 +195,17 @@ describe("Contract 'CreditAgent'", async () => {
   const REVERT_ERROR_IF_PROGRAM_ID_ZERO = "CreditAgent_ProgramIdZero";
   const REVERT_ERROR_IF_SAFE_CAST_OVERFLOWED_UINT_DOWNCAST = "SafeCast_OverflowedUintDowncast";
   const REVERT_ERROR_IF_TX_ID_ZERO = "CreditAgent_TxIdZero";
+  const REVERT_ERROR_IF_INVALID_INPUT_ARRAYS = "CreditAgent_InvalidInputArrays";
 
   const EVENT_NAME_MOCK_CONFIGURE_CASH_OUT_HOOKS_CALLED = "MockConfigureCashOutHooksCalled";
   const EVENT_NAME_MOCK_REVOKE_LOAN_CALLED = "MockRevokeLoanCalled";
   const EVENT_NAME_MOCK_TAKE_LOAN_FOR_CALLED = "MockTakeLoanForCalled";
+  const EVENT_NAME_MOCK_TAKE_INSTALLMENT_LOAN_FOR_CALLED = "MockTakeInstallmentLoanForCalled";
+  const EVENT_NAME_MOCK_REVOKE_INSTALLMENT_LOAN_CALLED = "MockRevokeInstallmentLoanCalled";
   const EVENT_NAME_LENDING_MARKET_CHANGED = "LendingMarketChanged";
   const EVENT_NAME_CASHIER_CHANGED = "CashierChanged";
   const EVENT_NAME_CREDIT_STATUS_CHANGED = "CreditStatusChanged";
+  const EVENT_NAME_INSTALLMENT_CREDIT_STATUS_CHANGED = "InstallmentCreditStatusChanged";
 
   let creditAgentFactory: ContractFactory;
   let cashierMockFactory: ContractFactory;
@@ -241,30 +293,16 @@ describe("Contract 'CreditAgent'", async () => {
     return { fixture, txId, initCredit, initCashOut };
   }
 
-  function defineCredit(props: {
-    borrowerAddress?: string;
-    programId?: number;
-    durationInPeriods?: number;
-    status?: CreditStatus;
-    loanAmount?: bigint;
-    loanAddon?: bigint;
-    loanId?: bigint;
-  } = {}): Credit {
-    const borrowerAddress: string = props.borrowerAddress ?? borrower.address;
-    const programId: number = props.programId ?? LOAN_PROGRAM_ID_STUB;
-    const durationInPeriods: number = props.durationInPeriods ?? LOAN_DURATION_IN_SECONDS_STUB;
-    const status = props.status ?? CreditStatus.Nonexistent;
-    const loanAmount = props.loanAmount ?? LOAN_AMOUNT_STUB;
-    const loanAddon = props.loanAddon ?? LOAN_ADDON_STUB;
-    const loanId = props.loanId ?? 0n;
+  function defineCredit(props: Partial<Credit> = {}): Credit {
     return {
-      borrower: borrowerAddress,
-      programId,
-      durationInPeriods,
-      status,
-      loanAmount,
-      loanAddon,
-      loanId
+      ...initialCredit,
+      borrower: props.borrower ?? borrower.address,
+      programId: props.programId ?? LOAN_PROGRAM_ID_STUB,
+      durationInPeriods: props.durationInPeriods ?? LOAN_DURATION_IN_SECONDS_STUB,
+      status: props.status ?? CreditStatus.Nonexistent,
+      loanAmount: props.loanAmount ?? LOAN_AMOUNT_STUB,
+      loanAddon: props.loanAddon ?? LOAN_ADDON_STUB,
+      loanId: props.loanId ?? 0n
     };
   }
 
@@ -306,11 +344,94 @@ describe("Contract 'CreditAgent'", async () => {
     );
     await expect(tx).to.emit(cashierMock, EVENT_NAME_MOCK_CONFIGURE_CASH_OUT_HOOKS_CALLED).withArgs(
       txId,
-      getAddress(creditAgent), // newCallableContract,
+      getAddress(creditAgent), // newCallableContract
       NEEDED_CASHIER_CASH_OUT_HOOK_FLAGS // newHookFlags
     );
     credit.status = CreditStatus.Initiated;
     checkEquality(await creditAgent.getCredit(txId) as Credit, credit);
+  }
+
+  async function deployAndConfigureContractsThenInitiateInstallmentCredit(): Promise<{
+    fixture: Fixture;
+    txId: string;
+    initCredit: InstallmentCredit;
+    initCashOut: CashOut;
+  }> {
+    const fixture = await deployAndConfigureContracts();
+    const { creditAgent, cashierMock } = fixture;
+    const txId = TX_ID_STUB_INSTALLMENT;
+    const initCredit = defineInstallmentCredit();
+    const initCashOut: CashOut = {
+      ...initialCashOut,
+      account: borrower.address,
+      amount: initCredit.borrowAmounts.reduce((acc, val) => acc + val, 0n)
+    };
+
+    await proveTx(initiateInstallmentCredit(creditAgent, { txId, credit: initCredit }));
+    await proveTx(cashierMock.setCashOut(txId, initCashOut));
+
+    return { fixture, txId, initCredit, initCashOut };
+  }
+
+  function defineInstallmentCredit(props: Partial<InstallmentCredit> = {}): InstallmentCredit {
+    return {
+      ...initialInstallmentCredit,
+      borrower: props.borrower ?? borrower.address,
+      programId: props.programId ?? LOAN_PROGRAM_ID_STUB,
+      status: props.status ?? CreditStatus.Nonexistent,
+      durationsInPeriods: props.durationsInPeriods ?? [10, 20],
+      borrowAmounts: props.borrowAmounts ?? [BigInt(1000), BigInt(2000)],
+      addonAmounts: props.addonAmounts ?? [BigInt(100), BigInt(200)],
+      firstInstallmentId: props.firstInstallmentId ?? 0n
+    };
+  }
+
+  function initiateInstallmentCredit(
+    creditAgent: Contract,
+    props: {
+      txId?: string;
+      credit?: InstallmentCredit;
+      caller?: HardhatEthersSigner;
+    } = {}
+  ): Promise<TransactionResponse> {
+    const caller = props.caller ?? manager;
+    const txId = props.txId ?? TX_ID_STUB_INSTALLMENT;
+    const credit = props.credit ?? defineInstallmentCredit();
+    return connect(creditAgent, caller).initiateInstallmentCredit(
+      txId,
+      credit.borrower,
+      credit.programId,
+      credit.durationsInPeriods,
+      credit.borrowAmounts,
+      credit.addonAmounts
+    );
+  }
+
+  async function checkInstallmentCreditInitiation(fixture: Fixture, props: {
+    tx: Promise<TransactionResponse>;
+    txId: string;
+    credit: InstallmentCredit;
+  }) {
+    const { creditAgent, cashierMock } = fixture;
+    const { tx, txId, credit } = props;
+    await expect(tx).to.emit(creditAgent, EVENT_NAME_INSTALLMENT_CREDIT_STATUS_CHANGED).withArgs(
+      txId,
+      credit.borrower,
+      CreditStatus.Initiated, // newStatus
+      CreditStatus.Nonexistent, // oldStatus
+      credit.firstInstallmentId,
+      credit.programId,
+      credit.durationsInPeriods,
+      credit.borrowAmounts,
+      credit.addonAmounts
+    );
+    await expect(tx).to.emit(cashierMock, EVENT_NAME_MOCK_CONFIGURE_CASH_OUT_HOOKS_CALLED).withArgs(
+      txId,
+      getAddress(creditAgent), // newCallableContract
+      NEEDED_CASHIER_CASH_OUT_HOOK_FLAGS // newHookFlags
+    );
+    credit.status = CreditStatus.Initiated;
+    checkEquality(await creditAgent.getInstallmentCredit(txId) as InstallmentCredit, credit);
   }
 
   describe("Function 'initialize()'", async () => {
@@ -681,7 +802,7 @@ describe("Contract 'CreditAgent'", async () => {
 
       it("The provided borrower address is zero", async () => {
         const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
-        const credit = defineCredit({ borrowerAddress: ADDRESS_ZERO });
+        const credit = defineCredit({ borrower: ADDRESS_ZERO });
 
         await expect(
           initiateCredit(creditAgent, { credit })
@@ -852,7 +973,7 @@ describe("Contract 'CreditAgent'", async () => {
     // Additional more complex checks are in the other sections
   });
 
-  describe("Function 'onCashierHook()", async () => {
+  describe("Function 'onCashierHook()'", async () => {
     async function checkCashierHookCalling(fixture: Fixture, props: {
       txId: string;
       credit: Credit;
@@ -1102,7 +1223,7 @@ describe("Contract 'CreditAgent'", async () => {
 
         await expect(
           cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId)
-        ).to.revertedWithCustomError(
+        ).to.be.revertedWithCustomError(
           creditAgent,
           REVERT_ERROR_IF_CASH_OUT_PARAMETERS_INAPPROPRIATE
         ).withArgs(txId);
@@ -1119,7 +1240,7 @@ describe("Contract 'CreditAgent'", async () => {
 
         await expect(
           cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId)
-        ).to.revertedWithCustomError(
+        ).to.be.revertedWithCustomError(
           creditAgent,
           REVERT_ERROR_IF_CASH_OUT_PARAMETERS_INAPPROPRIATE
         ).withArgs(txId);
@@ -1177,6 +1298,7 @@ describe("Contract 'CreditAgent'", async () => {
       const tx = initiateCredit(creditAgent, { txId, credit });
       await checkCreditInitiation(fixture, { tx, txId, credit });
       const expectedAgentState: AgentState = {
+        ...initialAgentState,
         initiatedCreditCounter: 1n,
         pendingCreditCounter: 0n,
         configured: true
@@ -1301,6 +1423,747 @@ describe("Contract 'CreditAgent'", async () => {
 
       // Configuring is prohibited if a credit is initiated
       await proveTx(initiateCredit(creditAgent, { txId, credit }));
+      await checkConfiguringProhibition();
+
+      // Configuring is allowed if credits are reversed or confirmed and no more active credits exist
+      await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId));
+      await proveTx(
+        cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutConfirmationAfter, txId)
+      );
+      await checkConfiguringAllowance();
+    });
+  });
+
+  describe("Function 'initiateInstallmentCredit()'", async () => {
+    describe("Executes as expected if", async () => {
+      it("The 'addonAmounts' values are not zero", async () => {
+        const fixture = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({ addonAmounts: [LOAN_ADDON_STUB, LOAN_ADDON_STUB] });
+        const txId = TX_ID_STUB_INSTALLMENT;
+        const tx = initiateInstallmentCredit(fixture.creditAgent, { txId, credit });
+        await checkInstallmentCreditInitiation(fixture, { tx, txId, credit });
+      });
+      it("The 'addonAmounts' values are zero", async () => {
+        const fixture = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({ addonAmounts: [0n, 0n] });
+        const txId = TX_ID_STUB_INSTALLMENT;
+        const tx = initiateInstallmentCredit(fixture.creditAgent, { txId, credit });
+        await checkInstallmentCreditInitiation(fixture, { tx, txId, credit });
+      });
+    });
+
+    describe("Is reverted if", async () => {
+      it("The contract is paused", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        await proveTx(creditAgent.pause());
+
+        await expect(
+          initiateInstallmentCredit(creditAgent)
+        ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("The caller does not have the manager role", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+
+        await expect(
+          initiateInstallmentCredit(creditAgent, { caller: deployer })
+        ).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_UNAUTHORIZED_ACCOUNT
+        ).withArgs(deployer.address, managerRole);
+      });
+
+      it("The 'Cashier' contract address is not configured", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        await proveTx(creditAgent.setCashier(ADDRESS_ZERO));
+
+        await expect(
+          initiateInstallmentCredit(creditAgent)
+        ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_CONTRACT_NOT_CONFIGURED);
+      });
+
+      it("The 'LendingMarket' contract address is not configured", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        await proveTx(creditAgent.setLendingMarket(ADDRESS_ZERO));
+
+        await expect(
+          initiateInstallmentCredit(creditAgent)
+        ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_CONTRACT_NOT_CONFIGURED);
+      });
+
+      it("The provided 'txId' value is zero", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({});
+
+        await expect(
+          initiateInstallmentCredit(creditAgent, { txId: TX_ID_ZERO, credit })
+        ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_TX_ID_ZERO);
+      });
+
+      it("The provided borrower address is zero", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({ borrower: ADDRESS_ZERO });
+
+        await expect(
+          initiateInstallmentCredit(creditAgent, { credit })
+        ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_BORROWER_ADDRESS_ZERO);
+      });
+
+      it("The provided program ID is zero", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({ programId: 0 });
+
+        await expect(
+          initiateInstallmentCredit(creditAgent, { credit })
+        ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_PROGRAM_ID_ZERO);
+      });
+
+      it("The provided loan duration is zero", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({ durationsInPeriods: [0, 20] });
+
+        await expect(
+          initiateInstallmentCredit(creditAgent, { credit })
+        ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_LOAN_DURATION_ZERO);
+      });
+
+      it("The provided loan amount is zero", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({ borrowAmounts: [100n, 0n] });
+
+        await expect(
+          initiateInstallmentCredit(creditAgent, { credit })
+        ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_LOAN_AMOUNT_ZERO);
+      });
+
+      it("A credit is already initiated for the provided transaction ID", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit();
+        const txId = TX_ID_STUB_INSTALLMENT;
+        await proveTx(initiateInstallmentCredit(creditAgent, { txId, credit }));
+
+        await expect(
+          initiateInstallmentCredit(creditAgent, { txId, credit })
+        ).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_CREDIT_STATUS_INAPPROPRIATE
+        ).withArgs(
+          txId,
+          CreditStatus.Initiated // status
+        );
+      });
+
+      it("The 'programId' argument is greater than unsigned 32-bit integer", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({ programId: Math.pow(2, 32) });
+        await expect(
+          initiateInstallmentCredit(creditAgent, { credit })
+        ).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_SAFE_CAST_OVERFLOWED_UINT_DOWNCAST
+        ).withArgs(32, credit.programId);
+      });
+
+      it("The 'durationInPeriods' argument is greater than unsigned 32-bit integer", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({ durationsInPeriods: [Math.pow(2, 32), 20] });
+        await expect(
+          initiateInstallmentCredit(creditAgent, { credit })
+        ).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_SAFE_CAST_OVERFLOWED_UINT_DOWNCAST
+        ).withArgs(32, credit.durationsInPeriods[0]);
+      });
+
+      it("The 'loanAmount' argument is greater than unsigned 64-bit integer", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({ borrowAmounts: [100n, 2n ** 64n] });
+        await expect(
+          initiateInstallmentCredit(creditAgent, { credit })
+        ).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_SAFE_CAST_OVERFLOWED_UINT_DOWNCAST
+        ).withArgs(64, credit.borrowAmounts[1]);
+      });
+
+      it("The 'loanAddon' argument is greater than unsigned 64-bit integer", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({ addonAmounts: [100n, 2n ** 64n] });
+        await expect(
+          initiateInstallmentCredit(creditAgent, { credit })
+        ).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_SAFE_CAST_OVERFLOWED_UINT_DOWNCAST
+        ).withArgs(64, credit.addonAmounts[1]);
+      });
+
+      it("The 'durationsInPeriods' array has different length than other arrays", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({
+          durationsInPeriods: [10],
+          borrowAmounts: [1000n, 2000n],
+          addonAmounts: [100n, 200n]
+        });
+        await expect(initiateInstallmentCredit(creditAgent, { credit })).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_INVALID_INPUT_ARRAYS
+        );
+      });
+
+      it("The 'borrowAmounts' array has different length than other arrays", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({
+          durationsInPeriods: [10, 20],
+          borrowAmounts: [1000n],
+          addonAmounts: [100n, 200n]
+        });
+        await expect(initiateInstallmentCredit(creditAgent, { credit })).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_INVALID_INPUT_ARRAYS
+        );
+      });
+
+      it("The 'addonAmounts' array has different length than other arrays", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({
+          durationsInPeriods: [10, 20],
+          borrowAmounts: [1000n, 2000n],
+          addonAmounts: [100n]
+        });
+        await expect(initiateInstallmentCredit(creditAgent, { credit })).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_INVALID_INPUT_ARRAYS
+        );
+      });
+
+      // Additional more complex checks are in the other sections
+    });
+  });
+
+  describe("Function 'revokeInstallmentCredit()", async () => {
+    it("Executes as expected", async () => {
+      const { creditAgent, cashierMock } = await setUpFixture(deployAndConfigureContracts);
+      const credit = defineInstallmentCredit();
+      const txId = TX_ID_STUB_INSTALLMENT;
+      await proveTx(initiateInstallmentCredit(creditAgent, { txId, credit }));
+
+      const tx = connect(creditAgent, manager).revokeInstallmentCredit(txId);
+      await expect(tx).to.emit(creditAgent, EVENT_NAME_INSTALLMENT_CREDIT_STATUS_CHANGED).withArgs(
+        txId,
+        credit.borrower,
+        CreditStatus.Nonexistent, // newStatus
+        CreditStatus.Initiated, // oldStatus
+        credit.firstInstallmentId,
+        credit.programId,
+        credit.durationsInPeriods,
+        credit.borrowAmounts,
+        credit.addonAmounts
+      );
+      await expect(tx).to.emit(cashierMock, EVENT_NAME_MOCK_CONFIGURE_CASH_OUT_HOOKS_CALLED).withArgs(
+        txId,
+        ADDRESS_ZERO, // newCallableContract,
+        0 // newHookFlags
+      );
+      checkEquality(await creditAgent.getCredit(txId) as Credit, initialCredit);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+      await proveTx(creditAgent.pause());
+
+      await expect(
+        connect(creditAgent, manager).revokeInstallmentCredit(TX_ID_STUB_INSTALLMENT)
+      ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the manager role", async () => {
+      const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+
+      await expect(
+        connect(creditAgent, deployer).revokeInstallmentCredit(TX_ID_STUB_INSTALLMENT)
+      ).to.be.revertedWithCustomError(
+        creditAgent,
+        REVERT_ERROR_IF_UNAUTHORIZED_ACCOUNT
+      ).withArgs(deployer.address, managerRole);
+    });
+
+    it("Is reverted if the provided 'txId' value is zero", async () => {
+      const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+
+      await expect(
+        connect(creditAgent, manager).revokeInstallmentCredit(TX_ID_ZERO)
+      ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_TX_ID_ZERO);
+    });
+
+    it("Is reverted if the credit does not exist", async () => {
+      const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+
+      await expect(
+        connect(creditAgent, manager).revokeInstallmentCredit(TX_ID_STUB_INSTALLMENT)
+      ).to.be.revertedWithCustomError(
+        creditAgent,
+        REVERT_ERROR_IF_CREDIT_STATUS_INAPPROPRIATE
+      ).withArgs(
+        TX_ID_STUB_INSTALLMENT,
+        CreditStatus.Nonexistent // status
+      );
+    });
+
+    // Additional more complex checks are in the other sections
+  });
+
+  describe("Function 'onCashierHook()' for installment credit", async () => {
+    async function checkCashierHookCalling(fixture: Fixture, props: {
+      txId: string;
+      credit: InstallmentCredit;
+      hookIndex: HookIndex;
+      newCreditStatus: CreditStatus;
+      oldCreditStatus: CreditStatus;
+    }) {
+      const { creditAgent, cashierMock, lendingMarketMock } = fixture;
+      const { credit, txId, hookIndex, newCreditStatus, oldCreditStatus } = props;
+
+      const tx = cashierMock.callCashierHook(getAddress(creditAgent), hookIndex, txId);
+
+      credit.status = newCreditStatus;
+
+      if (oldCreditStatus !== newCreditStatus) {
+        await expect(tx).to.emit(creditAgent, EVENT_NAME_INSTALLMENT_CREDIT_STATUS_CHANGED).withArgs(
+          txId,
+          credit.borrower,
+          newCreditStatus,
+          oldCreditStatus,
+          credit.firstInstallmentId,
+          credit.programId,
+          credit.durationsInPeriods,
+          credit.borrowAmounts,
+          credit.addonAmounts
+        );
+        if (newCreditStatus == CreditStatus.Pending) {
+          await expect(tx).to.emit(lendingMarketMock, EVENT_NAME_MOCK_TAKE_INSTALLMENT_LOAN_FOR_CALLED).withArgs(
+            credit.borrower,
+            credit.programId,
+            credit.borrowAmounts,
+            credit.addonAmounts,
+            credit.durationsInPeriods
+          );
+        } else {
+          await expect(tx).not.to.emit(lendingMarketMock, EVENT_NAME_MOCK_TAKE_INSTALLMENT_LOAN_FOR_CALLED);
+        }
+
+        if (newCreditStatus == CreditStatus.Reversed) {
+          await expect(tx).to.emit(lendingMarketMock, EVENT_NAME_MOCK_REVOKE_INSTALLMENT_LOAN_CALLED).withArgs(credit.firstInstallmentId);
+        } else {
+          await expect(tx).not.to.emit(lendingMarketMock, EVENT_NAME_MOCK_REVOKE_INSTALLMENT_LOAN_CALLED);
+        }
+      } else {
+        await expect(tx).not.to.emit(creditAgent, EVENT_NAME_INSTALLMENT_CREDIT_STATUS_CHANGED);
+      }
+
+      checkEquality(await creditAgent.getInstallmentCredit(txId) as InstallmentCredit, credit);
+    }
+
+    describe("Executes as expected if", async () => {
+      it("A cash-out requested and then confirmed with other proper conditions", async () => {
+        const { fixture, txId, initCredit } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+        const expectedAgentState: AgentState = {
+          ...initialAgentState,
+          initiatedInstallmentCreditCounter: 1n,
+          configured: true
+        };
+        checkEquality(await fixture.creditAgent.agentState() as AgentState, expectedAgentState);
+        const credit: InstallmentCredit = { ...initCredit, firstInstallmentId: fixture.loanIdStub };
+
+        // Emulate cash-out request
+        await checkCashierHookCalling(
+          fixture,
+          {
+            txId,
+            credit,
+            hookIndex: HookIndex.CashOutRequestBefore,
+            newCreditStatus: CreditStatus.Pending,
+            oldCreditStatus: CreditStatus.Initiated
+          }
+        );
+        expectedAgentState.initiatedInstallmentCreditCounter = 0n;
+        expectedAgentState.pendingInstallmentCreditCounter = 1n;
+        checkEquality(await fixture.creditAgent.agentState() as AgentState, expectedAgentState);
+
+        // Emulate cash-out confirmation
+        await checkCashierHookCalling(
+          fixture,
+          {
+            txId,
+            credit,
+            hookIndex: HookIndex.CashOutConfirmationAfter,
+            newCreditStatus: CreditStatus.Confirmed,
+            oldCreditStatus: CreditStatus.Pending
+          }
+        );
+        expectedAgentState.pendingInstallmentCreditCounter = 0n;
+        checkEquality(await fixture.creditAgent.agentState() as AgentState, expectedAgentState);
+      });
+
+      it("A cash-out requested and then reversed with other proper conditions", async () => {
+        const { fixture, txId, initCredit } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+        const credit: InstallmentCredit = { ...initCredit, firstInstallmentId: fixture.loanIdStub };
+
+        // Emulate cash-out request
+        await checkCashierHookCalling(
+          fixture,
+          {
+            txId,
+            credit,
+            hookIndex: HookIndex.CashOutRequestBefore,
+            newCreditStatus: CreditStatus.Pending,
+            oldCreditStatus: CreditStatus.Initiated
+          }
+        );
+        const expectedAgentState: AgentState = {
+          ...initialAgentState,
+          pendingInstallmentCreditCounter: 1n,
+          configured: true
+        };
+        checkEquality(await fixture.creditAgent.agentState() as AgentState, expectedAgentState);
+
+        // Emulate cash-out reversal
+        await checkCashierHookCalling(
+          fixture,
+          {
+            txId,
+            credit,
+            hookIndex: HookIndex.CashOutReversalAfter,
+            newCreditStatus: CreditStatus.Reversed,
+            oldCreditStatus: CreditStatus.Pending
+          }
+        );
+        expectedAgentState.pendingInstallmentCreditCounter = 0n;
+        checkEquality(await fixture.creditAgent.agentState() as AgentState, expectedAgentState);
+      });
+    });
+
+    describe("Is reverted if", async () => {
+      async function checkCashierHookInappropriateStatusError(fixture: Fixture, props: {
+        txId: string;
+        hookIndex: HookIndex;
+        CreditStatus: CreditStatus;
+      }) {
+        const { creditAgent, cashierMock } = fixture;
+        const { txId, hookIndex, CreditStatus } = props;
+        await expect(
+          cashierMock.callCashierHook(getAddress(creditAgent), hookIndex, TX_ID_STUB_INSTALLMENT)
+        ).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_CREDIT_STATUS_INAPPROPRIATE
+        ).withArgs(
+          txId,
+          CreditStatus // status
+        );
+      }
+
+      it("The contract is paused (DUPLICATE)", async () => {
+        const { fixture } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+        const { creditAgent, cashierMock } = fixture;
+        const hookIndex = HookIndex.CashOutRequestBefore;
+        await proveTx(creditAgent.pause());
+
+        await expect(
+          cashierMock.callCashierHook(getAddress(creditAgent), hookIndex, TX_ID_STUB)
+        ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("The caller is not the configured 'Cashier' contract (DUPLICATE)", async () => {
+        const { fixture } = await setUpFixture(deployAndConfigureContractsThenInitiateCredit);
+        const { creditAgent } = fixture;
+        const hookIndex = HookIndex.CashOutRequestBefore;
+
+        await expect(
+          connect(creditAgent, deployer).onCashierHook(hookIndex, TX_ID_STUB)
+        ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_CASHIER_HOOK_CALLER_UNAUTHORIZED);
+      });
+
+      it("The credit status is inappropriate to the provided hook index. Part 1", async () => {
+        const { fixture, txId } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+        const { creditAgent, cashierMock } = fixture;
+
+        // Try for a credit with the initiated status
+        await checkCashierHookInappropriateStatusError(fixture, {
+          txId,
+          hookIndex: HookIndex.CashOutConfirmationAfter,
+          CreditStatus: CreditStatus.Initiated
+        });
+        await checkCashierHookInappropriateStatusError(fixture, {
+          txId,
+          hookIndex: HookIndex.CashOutReversalAfter,
+          CreditStatus: CreditStatus.Initiated
+        });
+
+        // Try for a credit with the pending status
+        await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId));
+        await checkCashierHookInappropriateStatusError(fixture, {
+          txId,
+          hookIndex: HookIndex.CashOutRequestBefore,
+          CreditStatus: CreditStatus.Pending
+        });
+
+        // Try for a credit with the confirmed status
+        await proveTx(
+          cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutConfirmationAfter, txId)
+        );
+        await checkCashierHookInappropriateStatusError(fixture, {
+          txId,
+          hookIndex: HookIndex.CashOutRequestBefore,
+          CreditStatus: CreditStatus.Confirmed
+        });
+        await checkCashierHookInappropriateStatusError(fixture, {
+          txId,
+          hookIndex: HookIndex.CashOutConfirmationAfter,
+          CreditStatus: CreditStatus.Confirmed
+        });
+        await checkCashierHookInappropriateStatusError(fixture, {
+          txId,
+          hookIndex: HookIndex.CashOutReversalAfter,
+          CreditStatus: CreditStatus.Confirmed
+        });
+      });
+
+      it("The credit status is inappropriate to the provided hook index. Part 2", async () => {
+        const { fixture, txId } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+        const { creditAgent, cashierMock } = fixture;
+
+        // Try for a credit with the reversed status
+        await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId));
+        await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutReversalAfter, txId));
+        await checkCashierHookInappropriateStatusError(fixture, {
+          txId,
+          hookIndex: HookIndex.CashOutRequestBefore,
+          CreditStatus: CreditStatus.Reversed
+        });
+        await checkCashierHookInappropriateStatusError(fixture, {
+          txId,
+          hookIndex: HookIndex.CashOutConfirmationAfter,
+          CreditStatus: CreditStatus.Reversed
+        });
+        await checkCashierHookInappropriateStatusError(fixture, {
+          txId,
+          hookIndex: HookIndex.CashOutReversalAfter,
+          CreditStatus: CreditStatus.Reversed
+        });
+      });
+
+      it("The cash-out account is not match the credit borrower before taking a loan", async () => {
+        const { fixture, txId, initCashOut } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+        const { creditAgent, cashierMock } = fixture;
+        const cashOut: CashOut = {
+          ...initCashOut,
+          account: deployer.address
+        };
+        await proveTx(cashierMock.setCashOut(txId, cashOut));
+
+        await expect(
+          cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId)
+        ).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_CASH_OUT_PARAMETERS_INAPPROPRIATE
+        ).withArgs(txId);
+      });
+
+      it("The cash-out amount is not match the credit amount before taking a loan", async () => {
+        const { fixture, txId, initCashOut } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+        const { creditAgent, cashierMock } = fixture;
+        const cashOut: CashOut = {
+          ...initCashOut,
+          amount: initCashOut.amount + 1n
+        };
+        await proveTx(cashierMock.setCashOut(txId, cashOut));
+
+        await expect(
+          cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId)
+        ).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_CASH_OUT_PARAMETERS_INAPPROPRIATE
+        ).withArgs(txId);
+      });
+
+      it("The provided hook index is unexpected", async () => {
+        const { fixture } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+        const { creditAgent, cashierMock } = fixture;
+        const hookIndex = HookIndex.Unused;
+
+        await expect(
+          cashierMock.callCashierHook(getAddress(creditAgent), hookIndex, TX_ID_STUB)
+        ).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_CASHIER_HOOK_INDEX_UNEXPECTED
+        ).withArgs(
+          hookIndex,
+          TX_ID_STUB,
+          getAddress(cashierMock)
+        );
+      });
+    });
+  });
+
+  describe("Complex scenarios for installment credit", async () => {
+    it("A revoked credit can be re-initiated", async () => {
+      const { fixture, txId, initCredit } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+      const { creditAgent } = fixture;
+      const expectedAgentState: AgentState = {
+        ...initialAgentState,
+        initiatedInstallmentCreditCounter: 1n,
+        configured: true
+      };
+      const credit: InstallmentCredit = { ...initCredit };
+      checkEquality(await fixture.creditAgent.agentState() as AgentState, expectedAgentState);
+
+      await proveTx(connect(creditAgent, manager).revokeInstallmentCredit(txId));
+      expectedAgentState.initiatedInstallmentCreditCounter = 0n;
+      checkEquality(await fixture.creditAgent.agentState() as AgentState, expectedAgentState);
+
+      const tx = initiateInstallmentCredit(creditAgent, { txId, credit });
+      await checkInstallmentCreditInitiation(fixture, { tx, txId, credit });
+      expectedAgentState.initiatedInstallmentCreditCounter = 1n;
+      checkEquality(await fixture.creditAgent.agentState() as AgentState, expectedAgentState);
+    });
+
+    it("A reversed credit can be re-initiated", async () => {
+      const { fixture, txId, initCredit } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+      const { creditAgent, cashierMock } = fixture;
+      const credit: InstallmentCredit = { ...initCredit };
+
+      await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId));
+      await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutReversalAfter, txId));
+
+      const tx = initiateInstallmentCredit(creditAgent, { txId, credit });
+      await checkInstallmentCreditInitiation(fixture, { tx, txId, credit });
+      const expectedAgentState: AgentState = {
+        ...initialAgentState,
+        initiatedInstallmentCreditCounter: 1n,
+        pendingInstallmentCreditCounter: 0n,
+        configured: true
+      };
+      checkEquality(await fixture.creditAgent.agentState() as AgentState, expectedAgentState);
+    });
+
+    it("A pending or confirmed credit cannot be re-initiated", async () => {
+      const { fixture, txId, initCredit } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+      const { creditAgent, cashierMock } = fixture;
+      const credit: InstallmentCredit = { ...initCredit };
+
+      // Try for a credit with the pending status
+      await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId));
+      await expect(
+        initiateInstallmentCredit(creditAgent, { txId, credit })
+      ).to.be.revertedWithCustomError(
+        creditAgent,
+        REVERT_ERROR_IF_CREDIT_STATUS_INAPPROPRIATE
+      ).withArgs(
+        txId,
+        CreditStatus.Pending // status
+      );
+
+      // confirm => confirmed
+      await proveTx(
+        cashierMock.callCashierHook(
+          getAddress(creditAgent),
+          HookIndex.CashOutConfirmationAfter,
+          txId
+        )
+      );
+      // try re-initiate => revert with status=Confirmed
+      await expect(
+        initiateInstallmentCredit(creditAgent, { txId, credit })
+      ).to.be.revertedWithCustomError(
+        creditAgent,
+        REVERT_ERROR_IF_CREDIT_STATUS_INAPPROPRIATE
+      ).withArgs(txId, CreditStatus.Confirmed);
+    });
+
+    it("A credit with any status except initiated cannot be revoked", async () => {
+      const { fixture, txId, initCredit } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+      const { creditAgent, cashierMock } = fixture;
+      const credit: InstallmentCredit = { ...initCredit };
+
+      // Try for a credit with the pending status
+      await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId));
+      await expect(
+        connect(creditAgent, manager).revokeInstallmentCredit(txId)
+      ).to.be.revertedWithCustomError(
+        creditAgent,
+        REVERT_ERROR_IF_CREDIT_STATUS_INAPPROPRIATE
+      ).withArgs(
+        txId,
+        CreditStatus.Pending // status
+      );
+
+      // Try for a credit with the reversed status
+      await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutReversalAfter, txId));
+      await expect(
+        connect(creditAgent, manager).revokeInstallmentCredit(txId)
+      ).to.be.revertedWithCustomError(
+        creditAgent,
+        REVERT_ERROR_IF_CREDIT_STATUS_INAPPROPRIATE
+      ).withArgs(
+        txId,
+        CreditStatus.Reversed // status
+      );
+
+      // Try for a credit with the confirmed status
+      await proveTx(initiateInstallmentCredit(creditAgent, { txId, credit }));
+      await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId));
+      await proveTx(
+        cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutConfirmationAfter, txId)
+      );
+      await expect(
+        connect(creditAgent, manager).revokeInstallmentCredit(txId)
+      ).to.be.revertedWithCustomError(
+        creditAgent,
+        REVERT_ERROR_IF_CREDIT_STATUS_INAPPROPRIATE
+      ).withArgs(
+        txId,
+        CreditStatus.Confirmed // status
+      );
+    });
+
+    it("Configuring is prohibited when not all credits are processed", async () => {
+      const { fixture, txId, initCredit } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+      const { creditAgent, cashierMock, lendingMarketMock } = fixture;
+      const credit: InstallmentCredit = { ...initCredit };
+
+      async function checkConfiguringProhibition() {
+        await expect(
+          connect(creditAgent, admin).setCashier(ADDRESS_ZERO)
+        ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_CONFIGURING_PROHIBITED);
+        await expect(
+          connect(creditAgent, admin).setLendingMarket(ADDRESS_ZERO)
+        ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_CONFIGURING_PROHIBITED);
+      }
+
+      async function checkConfiguringAllowance() {
+        await proveTx(connect(creditAgent, admin).setCashier(ADDRESS_ZERO));
+        await proveTx(connect(creditAgent, admin).setLendingMarket(ADDRESS_ZERO));
+        await proveTx(connect(creditAgent, admin).setCashier(getAddress(cashierMock)));
+        await proveTx(connect(creditAgent, admin).setLendingMarket(getAddress(lendingMarketMock)));
+      }
+
+      // Configuring is prohibited if a credit is initiated
+      await checkConfiguringProhibition();
+
+      // Configuring is allowed when no credit is initiated
+      await proveTx(connect(creditAgent, manager).revokeInstallmentCredit(txId));
+      await checkConfiguringAllowance();
+
+      // Configuring is prohibited if a credit is pending
+      await proveTx(initiateInstallmentCredit(creditAgent, { txId, credit }));
+      await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId));
+      await checkConfiguringProhibition();
+
+      // Configuring is allowed if a credit is reversed and no more active credits exist
+      await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutReversalAfter, txId));
+      await checkConfiguringAllowance();
+
+      // Configuring is prohibited if a credit is initiated
+      await proveTx(initiateInstallmentCredit(creditAgent, { txId, credit }));
       await checkConfiguringProhibition();
 
       // Configuring is allowed if credits are reversed or confirmed and no more active credits exist

--- a/test/CreditAgent.test.ts
+++ b/test/CreditAgent.test.ts
@@ -195,7 +195,7 @@ describe("Contract 'CreditAgent'", async () => {
   const REVERT_ERROR_IF_PROGRAM_ID_ZERO = "CreditAgent_ProgramIdZero";
   const REVERT_ERROR_IF_SAFE_CAST_OVERFLOWED_UINT_DOWNCAST = "SafeCast_OverflowedUintDowncast";
   const REVERT_ERROR_IF_TX_ID_ZERO = "CreditAgent_TxIdZero";
-  const REVERT_ERROR_IF_INVALID_INPUT_ARRAYS = "CreditAgent_InvalidInputArrays";
+  const REVERT_ERROR_IF_INPUT_ARRAYS_INVALID = "CreditAgent_InputArraysInvalid";
   const REVERT_ERROR_IF_TX_ID_ALREADY_USED = "CreditAgent_TxIdAlreadyUsed";
   const REVERT_ERROR_IF_FAILED_TO_PROCESS_CASH_OUT_REQUEST_BEFORE = "CreditAgent_FailedToProcessCashOutRequestBefore";
   const REVERT_ERROR_IF_FAILED_TO_PROCESS_CASH_OUT_CONFIRMATION_AFTER = "CreditAgent_FailedToProcessCashOutConfirmationAfter";
@@ -1625,7 +1625,7 @@ describe("Contract 'CreditAgent'", async () => {
         });
         await expect(initiateInstallmentCredit(creditAgent, { credit })).to.be.revertedWithCustomError(
           creditAgent,
-          REVERT_ERROR_IF_INVALID_INPUT_ARRAYS
+          REVERT_ERROR_IF_INPUT_ARRAYS_INVALID
         );
       });
 
@@ -1638,7 +1638,7 @@ describe("Contract 'CreditAgent'", async () => {
         });
         await expect(initiateInstallmentCredit(creditAgent, { credit })).to.be.revertedWithCustomError(
           creditAgent,
-          REVERT_ERROR_IF_INVALID_INPUT_ARRAYS
+          REVERT_ERROR_IF_INPUT_ARRAYS_INVALID
         );
       });
 
@@ -1651,7 +1651,7 @@ describe("Contract 'CreditAgent'", async () => {
         });
         await expect(initiateInstallmentCredit(creditAgent, { credit })).to.be.revertedWithCustomError(
           creditAgent,
-          REVERT_ERROR_IF_INVALID_INPUT_ARRAYS
+          REVERT_ERROR_IF_INPUT_ARRAYS_INVALID
         );
       });
 
@@ -1664,7 +1664,7 @@ describe("Contract 'CreditAgent'", async () => {
         });
         await expect(initiateInstallmentCredit(creditAgent, { credit })).to.be.revertedWithCustomError(
           creditAgent,
-          REVERT_ERROR_IF_INVALID_INPUT_ARRAYS
+          REVERT_ERROR_IF_INPUT_ARRAYS_INVALID
         );
       });
 

--- a/test/CreditAgent.test.ts
+++ b/test/CreditAgent.test.ts
@@ -169,7 +169,7 @@ describe("Contract 'CreditAgent'", async () => {
     (1 << HookIndex.CashOutReversalAfter);
   const EXPECTED_VERSION: Version = {
     major: 1,
-    minor: 1,
+    minor: 2,
     patch: 0
   };
 


### PR DESCRIPTION
## Main changes

To support installment loans on the `CreditAgent` contract, new `initiateInstallmentCredit`, `revokeInstallmentCredit`, and `getInstallmentCredit` functions were added. When installment credit is initiated or its state is changed, the `InstallmentCreditStatusChanged` event is emitted.

```Solidity
    /**
     * @dev Emitted when the status of an installment credit is changed.
     * @param txId The unique identifier of the related cash-out operation.
     * @param borrower The address of the borrower.
     * @param newStatus The current status of the credit.
     * @param oldStatus The previous status of the credit.
     * @param firstInstallmentId The unique ID of the related first installment loan on the lending market or zero if not taken.
     * @param programId The unique identifier of the lending program for the credit.
     * @param lastDurationInPeriods The duration of the last installment in periods.
     * @param totalBorrowAmount The total amount of all installments.
     * @param totalAddonAmount The total addon amount of all installments.
     * @param installmentCount The number of installments.
     */
    event InstallmentCreditStatusChanged(
        bytes32 indexed txId,
        address indexed borrower,
        CreditStatus newStatus,
        CreditStatus oldStatus,
        uint256 firstInstallmentId,
        uint256 programId,
        uint256 lastDurationInPeriods,
        uint256 totalBorrowAmount,
        uint256 totalAddonAmount,
        uint256 installmentCount
    );

    /**
     * @dev Initiates an installment credit.
     *
     * This function is expected to be called by a limited number of accounts.
     *
     * @param txId The unique identifier of the related cash-out operation.
     * @param borrower The address of the borrower.
     * @param programId The unique identifier of the lending program for the credit.
     * @param durationsInPeriods The duration of each installment in periods.
     * @param borrowAmounts The amounts of each installment.
     * @param addonAmounts The addon amounts of each installment.
     */
    function initiateInstallmentCredit(
        bytes32 txId,
        address borrower,
        uint256 programId,
        uint256[] calldata durationsInPeriods,
        uint256[] calldata borrowAmounts,
        uint256[] calldata addonAmounts
    ) external;

    /**
     * @dev Revokes an installment credit.
     *
     * This function is expected to be called by a limited number of accounts.
     *
     * @param txId The unique identifier of the related cash-out operation.
     */
    function revokeInstallmentCredit(bytes32 txId) external;

    /**
     * @dev Returns an installment credit structure by its unique identifier.
     * @param txId The unique identifier of the related cash-out operation.
     * @return The installment credit structure.
     */
    function getInstallmentCredit(bytes32 txId) external view returns (InstallmentCredit memory);

    /// @dev The data of a single installment credit.
    struct InstallmentCredit {
        // Slot 1
        address borrower; // ------------- The address of the borrower.
        uint32 programId; // ------------- The unique identifier of a lending program for the credit.
        CreditStatus status; // ---------- The status of the credit, see {CreditStatus}.
        // uint56 __reserved; // --------- Reserved for future use until the end of the storage slot.
        // Slot 2
        uint32[] durationsInPeriods; // -- The duration of each installment in periods.
        // Slot 3
        uint64[] borrowAmounts; // ------- The amounts of each installment.
        // Slot 4
        uint64[] addonAmounts; // -------- The addon amounts of each installment.
        // Slot 5
        uint256 firstInstallmentId; // --- The unique ID of the related first installment loan on the lending market or zero if not taken.
    }
```

## Versioning 

The version of the `CreditAgent` contract has been changed: `1.1.0` => `1.2.0`.

## Test coverage

New functionality was fully covered by tests.