### PR TITLE
feat: introduce the grantor role and make other improvements

### DIFF
--- a/contracts/CreditAgent.sol
+++ b/contracts/CreditAgent.sol
@@ -77,8 +77,8 @@ contract CreditAgent is
     /// @dev The bit flags that represent the required hooks for cash-out operations.
     uint256 private constant REQUIRED_CASHIER_CASH_OUT_HOOK_FLAGS =
         (1 << uint256(ICashierHookableTypes.HookIndex.CashOutRequestBefore)) +
-            (1 << uint256(ICashierHookableTypes.HookIndex.CashOutConfirmationAfter)) +
-            (1 << uint256(ICashierHookableTypes.HookIndex.CashOutReversalAfter));
+        (1 << uint256(ICashierHookableTypes.HookIndex.CashOutConfirmationAfter)) +
+        (1 << uint256(ICashierHookableTypes.HookIndex.CashOutReversalAfter));
 
     // ------------------ Modifiers ------------------------------- //
 

--- a/contracts/CreditAgent.sol
+++ b/contracts/CreditAgent.sol
@@ -557,9 +557,9 @@ contract CreditAgent is
             oldStatus,
             installmentCredit.firstInstallmentId,
             installmentCredit.programId,
-            _toUint256Array(installmentCredit.durationsInPeriods),
-            _toUint256Array(installmentCredit.borrowAmounts),
-            _toUint256Array(installmentCredit.addonAmounts)
+            installmentCredit.durationsInPeriods.length,
+            _sumArray(installmentCredit.borrowAmounts),
+            _sumArray(installmentCredit.addonAmounts)
         );
 
         unchecked {

--- a/contracts/CreditAgent.sol
+++ b/contracts/CreditAgent.sol
@@ -465,7 +465,12 @@ contract CreditAgent is
      * @dev Checks the permission to configure this agent contract.
      */
     function _checkConfiguringPermission() internal view {
-        if (_agentState.initiatedCreditCounter > 0 || _agentState.pendingCreditCounter > 0) {
+        if (
+            _agentState.initiatedCreditCounter > 0 ||
+            _agentState.pendingCreditCounter > 0 ||
+            _agentState.initiatedInstallmentCreditCounter > 0 ||
+            _agentState.pendingInstallmentCreditCounter > 0
+        ) {
             revert CreditAgent_ConfiguringProhibited();
         }
     }
@@ -759,7 +764,7 @@ contract CreditAgent is
     function _processTakeInstallmentLoanFor(bytes32 txId) internal returns (bool) {
         InstallmentCredit storage installmentCredit = _installmentCredits[txId];
 
-        if (installmentCredit.status != CreditStatus.Initiated) {
+        if (installmentCredit.status == CreditStatus.Nonexistent) {
             return false;
         }
 

--- a/contracts/CreditAgentStorage.sol
+++ b/contracts/CreditAgentStorage.sol
@@ -20,6 +20,9 @@ abstract contract CreditAgentStorageV1 is ICreditAgentTypes {
 
     /// @dev The state of this agent contract.
     AgentState internal _agentState;
+
+    /// @dev The mapping of the installment credit structure for a related operation identifier.
+    mapping(bytes32 => InstallmentCredit) internal _installmentCredits;
 }
 
 /**
@@ -38,5 +41,5 @@ abstract contract CreditAgentStorage is CreditAgentStorageV1 {
      * @dev This empty reserved space is put in place to allow future versions to add new
      * variables without shifting down storage in the inheritance chain.
      */
-    uint256[46] private __gap;
+    uint256[45] private __gap;
 }

--- a/contracts/interfaces/ICreditAgent.sol
+++ b/contracts/interfaces/ICreditAgent.sol
@@ -220,9 +220,9 @@ interface ICreditAgentPrimary is ICreditAgentTypes {
      * @param oldStatus The previous status of the credit.
      * @param firstInstallmentId The unique ID of the related first installment loan on the lending market or zero if not taken.
      * @param programId The unique identifier of the lending program for the credit.
-     * @param durationsInPeriods The duration of each installment in periods.
-     * @param borrowAmounts The amounts of each installment.
-     * @param addonAmounts The addon amounts of each installment.
+     * @param installmentCount The number of installments.
+     * @param totalBorrowAmount The total amount of all installments.
+     * @param totalAddonAmount The total addon amount of all installments.
      */
     event InstallmentCreditStatusChanged(
         bytes32 indexed txId,
@@ -231,9 +231,9 @@ interface ICreditAgentPrimary is ICreditAgentTypes {
         CreditStatus oldStatus,
         uint256 firstInstallmentId,
         uint256 programId,
-        uint256[] durationsInPeriods,
-        uint256[] borrowAmounts,
-        uint256[] addonAmounts
+        uint256 installmentCount,
+        uint256 totalBorrowAmount,
+        uint256 totalAddonAmount
     );
 
     // ------------------ Functions ------------------------------- //

--- a/contracts/interfaces/ICreditAgent.sol
+++ b/contracts/interfaces/ICreditAgent.sol
@@ -62,13 +62,36 @@ interface ICreditAgentTypes {
         uint256 loanId; // ------------ The unique ID of the related loan on the lending market or zero if not taken.
     }
 
+    /// @dev The data of a single installment credit.
+    struct InstallmentCredit {
+        // Slot 1
+        address borrower; // ------------- The address of the borrower.
+        uint32 programId; // ------------- The unique identifier of a lending program for the credit.
+        CreditStatus status; // ---------- The status of the credit, see {CreditStatus}.
+        // uint56 __reserved; // --------- Reserved for future use until the end of the storage slot.
+
+        // Slot 2
+        uint32[] durationsInPeriods; // -- The duration of each installment in periods.
+
+        // Slot 3
+        uint64[] borrowAmounts; // ------- The amounts of each installment.
+
+        // Slot 4
+        uint64[] addonAmounts; // -------- The addon amounts of each installment.
+
+        // Slot 5
+        uint256 firstInstallmentId; // --- The unique ID of the related first installment loan on the lending market or zero if not taken.
+    }
+
     /// @dev The state of this agent contract.
     struct AgentState {
         // Slot 1
-        bool configured; // ---------------- True if the agent is properly configured.
-        uint64 initiatedCreditCounter; // -- The counter of initiated credits.
-        uint64 pendingCreditCounter; // ---- The counter of pending credits.
-        // uint120 __reserved; // ---------- Reserved for future use until the end of the storage slot.
+        bool configured; // --------------------------- True if the agent is properly configured.
+        uint64 initiatedCreditCounter; // ------------- The counter of initiated credits.
+        uint56 pendingCreditCounter; // --------------- The counter of pending credits.
+        uint64 initiatedInstallmentCreditCounter; // -- The counter of initiated installment credits.
+        uint56 pendingInstallmentCreditCounter; // ---- The counter of pending installment credits.
+        // uint8 __reserved; // ----------------------- Reserved for future use until the end of the storage slot.
     }
 }
 
@@ -126,11 +149,35 @@ interface ICreditAgentErrors is ICreditAgentTypes {
     /// @dev The zero loan duration has been passed as a function argument.
     error CreditAgent_LoanDurationZero();
 
+    /// @dev The input arrays are empty or have different lengths.
+    error CreditAgent_InvalidInputArrays();
+
     /// @dev The zero program ID has been passed as a function argument.
     error CreditAgent_ProgramIdZero();
 
     /// @dev The zero off-chain transaction identifier has been passed as a function argument.
     error CreditAgent_TxIdZero();
+
+    /// @dev The transaction identifier is already used.
+    error CreditAgent_TxIdAlreadyUsed();
+
+    /**
+     * @dev The related cash-out operation has failed to be processed by the cashier hook.
+     * @param txId The off-chain transaction identifier of the operation.
+     */
+    error CreditAgent_FailedToProcessCashOutRequestBefore(bytes32 txId);
+
+    /**
+     * @dev The related cash-out operation has failed to be processed by the cashier hook.
+     * @param txId The off-chain transaction identifier of the operation.
+     */
+    error CreditAgent_FailedToProcessCashOutConfirmationAfter(bytes32 txId);
+
+    /**
+     * @dev The related cash-out operation has failed to be processed by the cashier hook.
+     * @param txId The off-chain transaction identifier of the operation.
+     */
+    error CreditAgent_FailedToProcessCashOutReversalAfter(bytes32 txId);
 }
 
 /**
@@ -165,6 +212,30 @@ interface ICreditAgentPrimary is ICreditAgentTypes {
         uint256 loanAddon
     );
 
+    /**
+     * @dev Emitted when the status of an installment credit is changed.
+     * @param txId The unique identifier of the related cash-out operation.
+     * @param borrower The address of the borrower.
+     * @param newStatus The current status of the credit.
+     * @param oldStatus The previous status of the credit.
+     * @param firstInstallmentId The unique ID of the related first installment loan on the lending market or zero if not taken.
+     * @param programId The unique identifier of the lending program for the credit.
+     * @param durationsInPeriods The duration of each installment in periods.
+     * @param borrowAmounts The amounts of each installment.
+     * @param addonAmounts The addon amounts of each installment.
+     */
+    event InstallmentCreditStatusChanged(
+        bytes32 indexed txId,
+        address indexed borrower,
+        CreditStatus newStatus,
+        CreditStatus oldStatus,
+        uint256 firstInstallmentId,
+        uint256 programId,
+        uint256[] durationsInPeriods,
+        uint256[] borrowAmounts,
+        uint256[] addonAmounts
+    );
+
     // ------------------ Functions ------------------------------- //
 
     /**
@@ -189,6 +260,27 @@ interface ICreditAgentPrimary is ICreditAgentTypes {
     ) external;
 
     /**
+     * @dev Initiates an installment credit.
+     *
+     * This function is expected to be called by a limited number of accounts.
+     *
+     * @param txId The unique identifier of the related cash-out operation.
+     * @param borrower The address of the borrower.
+     * @param programId The unique identifier of the lending program for the credit.
+     * @param durationsInPeriods The duration of each installment in periods.
+     * @param borrowAmounts The amounts of each installment.
+     * @param addonAmounts The addon amounts of each installment.
+     */
+    function initiateInstallmentCredit(
+        bytes32 txId,
+        address borrower,
+        uint256 programId,
+        uint256[] calldata durationsInPeriods,
+        uint256[] calldata borrowAmounts,
+        uint256[] calldata addonAmounts
+    ) external;
+
+    /**
      * @dev Revokes a credit.
      *
      * This function is expected to be called by a limited number of accounts.
@@ -198,11 +290,27 @@ interface ICreditAgentPrimary is ICreditAgentTypes {
     function revokeCredit(bytes32 txId) external;
 
     /**
+     * @dev Revokes an installment credit.
+     *
+     * This function is expected to be called by a limited number of accounts.
+     *
+     * @param txId The unique identifier of the related cash-out operation.
+     */
+    function revokeInstallmentCredit(bytes32 txId) external;
+
+    /**
      * @dev Returns a credit structure by its unique identifier.
      * @param txId The unique identifier of the related cash-out operation.
      * @return The credit structure.
      */
     function getCredit(bytes32 txId) external view returns (Credit memory);
+
+    /**
+     * @dev Returns an installment credit structure by its unique identifier.
+     * @param txId The unique identifier of the related cash-out operation.
+     * @return The installment credit structure.
+     */
+    function getInstallmentCredit(bytes32 txId) external view returns (InstallmentCredit memory);
 
     /**
      * @dev Returns the state of this agent contract.

--- a/contracts/interfaces/ILendingMarket.sol
+++ b/contracts/interfaces/ILendingMarket.sol
@@ -9,7 +9,7 @@ pragma solidity ^0.8.0;
  */
 interface ILendingMarket {
     /**
-     * @dev Takes a loan for a provided account. Can be called only by an account with a special role.
+     * @dev Takes a common loan for a provided account.
      * @param borrower The account for whom the loan is taken.
      * @param programId The identifier of the program to take the loan from.
      * @param borrowAmount The desired amount of tokens to borrow.
@@ -26,8 +26,32 @@ interface ILendingMarket {
     ) external returns (uint256);
 
     /**
+     * @dev Takes an installment loan with multiple sub-loans for a provided account.
+     * @param borrower The account for whom the loan is taken.
+     * @param programId The identifier of the program to take the loan from.
+     * @param borrowAmounts The desired amounts of tokens to borrow for each installment.
+     * @param addonAmounts The off-chain calculated addon amounts for each installment.
+     * @param durationsInPeriods The desired duration of each installment in periods.
+     * @return firstInstallmentId The unique identifier of the first sub-loan of the installment loan.
+     * @return installmentCount The total number of installments.
+     */
+    function takeInstallmentLoanFor(
+        address borrower,
+        uint32 programId,
+        uint256[] calldata borrowAmounts,
+        uint256[] calldata addonAmounts,
+        uint256[] calldata durationsInPeriods
+    ) external returns (uint256 firstInstallmentId, uint256 installmentCount);
+
+    /**
      * @dev Revokes a loan.
      * @param loanId The unique identifier of the loan to revoke.
      */
     function revokeLoan(uint256 loanId) external;
+
+    /**
+     * @dev Revokes an installment loan by revoking all of its sub-loans.
+     * @param loanId The unique identifier of any sub-loan of the installment loan to revoke.
+     */
+    function revokeInstallmentLoan(uint256 loanId) external;
 }

--- a/contracts/mocks/LendingMarketMock.sol
+++ b/contracts/mocks/LendingMarketMock.sol
@@ -24,9 +24,9 @@ contract LendingMarketMock {
     event MockTakeInstallmentLoanForCalled(
         address borrower, // Tools: this comment prevents Prettier from formatting into a single line.
         uint256 programId,
-        uint256[] durationsInPeriods,
         uint256[] borrowAmounts,
-        uint256[] addonAmounts
+        uint256[] addonAmounts,
+        uint256[] durationsInPeriods
     );
 
     /// @dev Emitted when the `revokeLoan()` function is called with the parameters of the function.
@@ -66,19 +66,24 @@ contract LendingMarketMock {
         uint256[] memory borrowAmounts,
         uint256[] memory addonAmounts,
         uint256[] memory durationsInPeriods
-    ) external returns (uint256) {
+    ) external returns (uint256, uint256) {
         emit MockTakeInstallmentLoanForCalled(
             borrower, // Tools: this comment prevents Prettier from formatting into a single line.
             programId,
-            durationsInPeriods,
             borrowAmounts,
-            addonAmounts
+            addonAmounts,
+            durationsInPeriods
         );
-        return LOAN_ID_STAB;
+        return (LOAN_ID_STAB, 1);
     }
 
     /// @dev Imitates the same-name function a lending market contracts. Just emits an event about the call.
     function revokeLoan(uint256 loanId) external {
         emit MockRevokeLoanCalled(loanId);
+    }
+
+    /// @dev Imitates the same-name function a lending market contracts. Just emits an event about the call.
+    function revokeInstallmentLoan(uint256 loanId) external {
+        emit MockRevokeInstallmentLoanCalled(loanId);
     }
 }

--- a/contracts/mocks/LendingMarketMock.sol
+++ b/contracts/mocks/LendingMarketMock.sol
@@ -20,8 +20,20 @@ contract LendingMarketMock {
         uint256 durationInPeriods
     );
 
+    /// @dev Emitted when the `takeInstallmentLoanFor()` function is called with the parameters of the function.
+    event MockTakeInstallmentLoanForCalled(
+        address borrower, // Tools: this comment prevents Prettier from formatting into a single line.
+        uint256 programId,
+        uint256[] durationsInPeriods,
+        uint256[] borrowAmounts,
+        uint256[] addonAmounts
+    );
+
     /// @dev Emitted when the `revokeLoan()` function is called with the parameters of the function.
     event MockRevokeLoanCalled(uint256 loanId);
+
+    /// @dev Emitted when the `revokeInstallmentLoan()` function is called with the parameters of the function.
+    event MockRevokeInstallmentLoanCalled(uint256 loanId);
 
     /**
      * @dev Imitates the same-name function a lending market contracts.
@@ -40,6 +52,27 @@ contract LendingMarketMock {
             borrowAmount,
             addonAmount,
             durationInPeriods
+        );
+        return LOAN_ID_STAB;
+    }
+
+    /**
+     * @dev Imitates the same-name function a lending market contracts.
+     *      Just emits an event about the call and returns a constant.
+     */
+    function takeInstallmentLoanFor(
+        address borrower, // Tools: this comment prevents Prettier from formatting into a single line.
+        uint32 programId,
+        uint256[] memory borrowAmounts,
+        uint256[] memory addonAmounts,
+        uint256[] memory durationsInPeriods
+    ) external returns (uint256) {
+        emit MockTakeInstallmentLoanForCalled(
+            borrower, // Tools: this comment prevents Prettier from formatting into a single line.
+            programId,
+            durationsInPeriods,
+            borrowAmounts,
+            addonAmounts
         );
         return LOAN_ID_STAB;
     }

--- a/test/CreditAgent.test.ts
+++ b/test/CreditAgent.test.ts
@@ -425,9 +425,9 @@ describe("Contract 'CreditAgent'", async () => {
       CreditStatus.Nonexistent, // oldStatus
       credit.firstInstallmentId,
       credit.programId,
-      credit.durationsInPeriods,
-      credit.borrowAmounts,
-      credit.addonAmounts
+      credit.durationsInPeriods.length,
+      _sumArray(credit.borrowAmounts),
+      _sumArray(credit.addonAmounts)
     );
     await expect(tx).to.emit(cashierMock, EVENT_NAME_MOCK_CONFIGURE_CASH_OUT_HOOKS_CALLED).withArgs(
       txId,
@@ -436,6 +436,10 @@ describe("Contract 'CreditAgent'", async () => {
     );
     credit.status = CreditStatus.Initiated;
     checkEquality(await creditAgent.getInstallmentCredit(txId) as InstallmentCredit, credit);
+  }
+
+  function _sumArray(array: bigint[]): bigint {
+    return array.reduce((acc, val) => acc + val, 0n);
   }
 
   describe("Function 'initialize()'", async () => {
@@ -1694,9 +1698,9 @@ describe("Contract 'CreditAgent'", async () => {
         CreditStatus.Initiated, // oldStatus
         credit.firstInstallmentId,
         credit.programId,
-        credit.durationsInPeriods,
-        credit.borrowAmounts,
-        credit.addonAmounts
+        credit.durationsInPeriods.length,
+        _sumArray(credit.borrowAmounts),
+        _sumArray(credit.addonAmounts)
       );
       await expect(tx).to.emit(cashierMock, EVENT_NAME_MOCK_CONFIGURE_CASH_OUT_HOOKS_CALLED).withArgs(
         txId,
@@ -1774,9 +1778,9 @@ describe("Contract 'CreditAgent'", async () => {
           oldCreditStatus,
           credit.firstInstallmentId,
           credit.programId,
-          credit.durationsInPeriods,
-          credit.borrowAmounts,
-          credit.addonAmounts
+          credit.durationsInPeriods.length,
+          _sumArray(credit.borrowAmounts),
+          _sumArray(credit.addonAmounts)
         );
         if (newCreditStatus == CreditStatus.Pending) {
           await expect(tx).to.emit(lendingMarketMock, EVENT_NAME_MOCK_TAKE_INSTALLMENT_LOAN_FOR_CALLED).withArgs(

--- a/test/CreditAgent.test.ts
+++ b/test/CreditAgent.test.ts
@@ -904,7 +904,7 @@ describe("Contract 'CreditAgent'", async () => {
         ).withArgs(64, credit.loanAddon);
       });
 
-      it("The 'txId' argument is already used", async () => {
+      it("The 'txId' argument is already used for an installment credit", async () => {
         const { fixture, txId } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
         const commonCredit = defineCredit();
         await expect(
@@ -991,7 +991,7 @@ describe("Contract 'CreditAgent'", async () => {
     // Additional more complex checks are in the other sections
   });
 
-  describe("Function 'onCashierHook()'", async () => {
+  describe("Function 'onCashierHook()' for an ordinary credit", async () => {
     async function checkCashierHookCalling(fixture: Fixture, props: {
       txId: string;
       credit: Credit;
@@ -1456,14 +1456,14 @@ describe("Contract 'CreditAgent'", async () => {
     describe("Executes as expected if", async () => {
       it("The 'addonAmounts' values are not zero", async () => {
         const fixture = await setUpFixture(deployAndConfigureContracts);
-        const credit = defineInstallmentCredit({ addonAmounts: [LOAN_ADDON_STUB, LOAN_ADDON_STUB] });
+        const credit = defineInstallmentCredit({ addonAmounts: [LOAN_ADDON_STUB, LOAN_ADDON_STUB / 2n] });
         const txId = TX_ID_STUB_INSTALLMENT;
         const tx = initiateInstallmentCredit(fixture.creditAgent, { txId, credit });
         await checkInstallmentCreditInitiation(fixture, { tx, txId, credit });
       });
-      it("The 'addonAmounts' values are zero", async () => {
+      it("The one of the 'addonAmounts' values is zero", async () => {
         const fixture = await setUpFixture(deployAndConfigureContracts);
-        const credit = defineInstallmentCredit({ addonAmounts: [0n, 0n] });
+        const credit = defineInstallmentCredit({ addonAmounts: [LOAN_ADDON_STUB, 0n] });
         const txId = TX_ID_STUB_INSTALLMENT;
         const tx = initiateInstallmentCredit(fixture.creditAgent, { txId, credit });
         await checkInstallmentCreditInitiation(fixture, { tx, txId, credit });
@@ -1536,16 +1536,16 @@ describe("Contract 'CreditAgent'", async () => {
         ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_PROGRAM_ID_ZERO);
       });
 
-      it("The provided loan duration is zero", async () => {
+      it("The 'durationsInPeriods' array contains a zero value", async () => {
         const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
-        const credit = defineInstallmentCredit({ durationsInPeriods: [0, 20] });
+        const credit = defineInstallmentCredit({ durationsInPeriods: [20, 0] });
 
         await expect(
           initiateInstallmentCredit(creditAgent, { credit })
         ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_LOAN_DURATION_ZERO);
       });
 
-      it("The provided loan amount is zero", async () => {
+      it("The 'borrowAmounts' array contains a zero value", async () => {
         const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
         const credit = defineInstallmentCredit({ borrowAmounts: [100n, 0n] });
 
@@ -1667,7 +1667,7 @@ describe("Contract 'CreditAgent'", async () => {
         );
       });
 
-      it("The 'txId' argument is already used", async () => {
+      it("The 'txId' argument is already used for an ordinary credit", async () => {
         const { fixture, txId } = await setUpFixture(deployAndConfigureContractsThenInitiateCredit);
         const installmentCredit = defineInstallmentCredit();
         await expect(
@@ -1754,7 +1754,7 @@ describe("Contract 'CreditAgent'", async () => {
     // Additional more complex checks are in the other sections
   });
 
-  describe("Function 'onCashierHook()' for installment credit", async () => {
+  describe("Function 'onCashierHook()' for an installment credit", async () => {
     async function checkCashierHookCalling(fixture: Fixture, props: {
       txId: string;
       credit: InstallmentCredit;
@@ -2255,8 +2255,8 @@ describe("Contract 'CreditAgent'", async () => {
     });
   });
 
-  describe("Function 'onCashierHook()'", async () => {
-    it("Reverts if failed to process the cash-out request hook", async () => {
+  describe("Function 'onCashierHook()' is reverted as expected for an unknown credit in the case of", async () => {
+    it("A cash-out request hook", async () => {
       const { creditAgent, cashierMock } = await setUpFixture(deployAndConfigureContracts);
       const txId = TX_ID_STUB;
       await expect(
@@ -2267,7 +2267,7 @@ describe("Contract 'CreditAgent'", async () => {
       ).withArgs(txId);
     });
 
-    it("Reverts if failed to process the cash-out confirmation hook", async () => {
+    it("A cash-out confirmation hook", async () => {
       const { creditAgent, cashierMock } = await setUpFixture(deployAndConfigureContracts);
       const txId = TX_ID_STUB;
       await expect(
@@ -2278,7 +2278,7 @@ describe("Contract 'CreditAgent'", async () => {
       ).withArgs(txId);
     });
 
-    it("Reverts if failed to process the cash-out reversal hook", async () => {
+    it("A cash-out reversal hook", async () => {
       const { creditAgent, cashierMock } = await setUpFixture(deployAndConfigureContracts);
       const txId = TX_ID_STUB;
       await expect(

--- a/test/CreditAgent.test.ts
+++ b/test/CreditAgent.test.ts
@@ -35,6 +35,19 @@ interface Credit {
   [key: string]: bigint | string | number;
 }
 
+interface InstallmentCredit {
+  borrower: string;
+  programId: number;
+  status: CreditStatus;
+  durationsInPeriods: number[];
+  borrowAmounts: bigint[];
+  addonAmounts: bigint[];
+  firstInstallmentId: bigint;
+
+  // Indexing signature to ensure that fields are iterated over in a key-value style
+  [key: string]: bigint | string | number | number[] | bigint[];
+}
+
 interface Fixture {
   creditAgent: Contract;
   cashierMock: Contract;
@@ -46,6 +59,8 @@ interface AgentState {
   configured: boolean;
   initiatedCreditCounter: bigint;
   pendingCreditCounter: bigint;
+  initiatedInstallmentCreditCounter: bigint;
+  pendingInstallmentCreditCounter: bigint;
 
   // Indexing signature to ensure that fields are iterated over in a key-value style
   [key: string]: bigint | boolean;
@@ -62,14 +77,14 @@ interface Version {
   major: number;
   minor: number;
   patch: number;
-
-  [key: string]: number; // Indexing signature to ensure that fields are iterated over in a key-value style
 }
 
 const initialAgentState: AgentState = {
   configured: false,
   initiatedCreditCounter: 0n,
-  pendingCreditCounter: 0n
+  pendingCreditCounter: 0n,
+  initiatedInstallmentCreditCounter: 0n,
+  pendingInstallmentCreditCounter: 0n
 };
 
 const initialCredit: Credit = {
@@ -82,6 +97,16 @@ const initialCredit: Credit = {
   loanId: 0n
 };
 
+const initialInstallmentCredit: InstallmentCredit = {
+  borrower: ADDRESS_ZERO,
+  programId: 0,
+  status: CreditStatus.Nonexistent,
+  durationsInPeriods: [],
+  borrowAmounts: [],
+  addonAmounts: [],
+  firstInstallmentId: 0n
+};
+
 const initialCashOut: CashOut = {
   account: ADDRESS_ZERO,
   amount: 0n,
@@ -91,14 +116,36 @@ const initialCashOut: CashOut = {
 
 function checkEquality<T extends Record<string, unknown>>(actualObject: T, expectedObject: T) {
   Object.keys(expectedObject).forEach(property => {
-    const value = actualObject[property];
-    if (typeof value === "undefined" || typeof value === "function" || typeof value === "object") {
+    const actualValue = actualObject[property];
+    const expectedValue = expectedObject[property];
+
+    // Ensure the property is not missing or a function
+    if (typeof actualValue === "undefined" || typeof actualValue === "function") {
       throw Error(`Property "${property}" is not found`);
     }
-    expect(value).to.eq(
-      expectedObject[property],
-      `Mismatch in the "${property}" property`
-    );
+
+    // If the expected property is an array, compare arrays deeply
+    if (Array.isArray(expectedValue)) {
+      expect(Array.isArray(actualValue), `Property "${property}" is expected to be an array`).to.be.true;
+      expect(actualValue).to.deep.equal(
+        expectedValue,
+        `Mismatch in the "${property}" array property`
+      );
+    }
+    // If the expected property is an object (and not an array), handle nested object comparison
+    else if (typeof expectedValue === "object" && expectedValue !== null) {
+      expect(actualValue).to.deep.equal(
+        expectedValue,
+        `Mismatch in the "${property}" object property`
+      );
+    }
+    // Otherwise compare as primitive values
+    else {
+      expect(actualValue).to.eq(
+        expectedValue,
+        `Mismatch in the "${property}" property`
+      );
+    }
   });
 }
 
@@ -111,7 +158,8 @@ async function setUpFixture<T>(func: () => Promise<T>): Promise<T> {
 }
 
 describe("Contract 'CreditAgent'", async () => {
-  const TX_ID_STUB = ethers.encodeBytes32String("STUB_TRANSACTION_ID1");
+  const TX_ID_STUB = ethers.encodeBytes32String("STUB_TRANSACTION_ID_COMMON");
+  const TX_ID_STUB_INSTALLMENT = ethers.encodeBytes32String("STUB_TRANSACTION_ID_INSTALLMENT");
   const TX_ID_ZERO = ethers.ZeroHash;
   const LOAN_PROGRAM_ID_STUB = 0xFFFF_ABCD;
   const LOAN_DURATION_IN_SECONDS_STUB = 0xFFFF_DCBA;
@@ -147,13 +195,17 @@ describe("Contract 'CreditAgent'", async () => {
   const REVERT_ERROR_IF_PROGRAM_ID_ZERO = "CreditAgent_ProgramIdZero";
   const REVERT_ERROR_IF_SAFE_CAST_OVERFLOWED_UINT_DOWNCAST = "SafeCast_OverflowedUintDowncast";
   const REVERT_ERROR_IF_TX_ID_ZERO = "CreditAgent_TxIdZero";
+  const REVERT_ERROR_IF_INVALID_INPUT_ARRAYS = "CreditAgent_InvalidInputArrays";
 
   const EVENT_NAME_MOCK_CONFIGURE_CASH_OUT_HOOKS_CALLED = "MockConfigureCashOutHooksCalled";
   const EVENT_NAME_MOCK_REVOKE_LOAN_CALLED = "MockRevokeLoanCalled";
   const EVENT_NAME_MOCK_TAKE_LOAN_FOR_CALLED = "MockTakeLoanForCalled";
+  const EVENT_NAME_MOCK_TAKE_INSTALLMENT_LOAN_FOR_CALLED = "MockTakeInstallmentLoanForCalled";
+  const EVENT_NAME_MOCK_REVOKE_INSTALLMENT_LOAN_CALLED = "MockRevokeInstallmentLoanCalled";
   const EVENT_NAME_LENDING_MARKET_CHANGED = "LendingMarketChanged";
   const EVENT_NAME_CASHIER_CHANGED = "CashierChanged";
   const EVENT_NAME_CREDIT_STATUS_CHANGED = "CreditStatusChanged";
+  const EVENT_NAME_INSTALLMENT_CREDIT_STATUS_CHANGED = "InstallmentCreditStatusChanged";
 
   let creditAgentFactory: ContractFactory;
   let cashierMockFactory: ContractFactory;
@@ -241,30 +293,16 @@ describe("Contract 'CreditAgent'", async () => {
     return { fixture, txId, initCredit, initCashOut };
   }
 
-  function defineCredit(props: {
-    borrowerAddress?: string;
-    programId?: number;
-    durationInPeriods?: number;
-    status?: CreditStatus;
-    loanAmount?: bigint;
-    loanAddon?: bigint;
-    loanId?: bigint;
-  } = {}): Credit {
-    const borrowerAddress: string = props.borrowerAddress ?? borrower.address;
-    const programId: number = props.programId ?? LOAN_PROGRAM_ID_STUB;
-    const durationInPeriods: number = props.durationInPeriods ?? LOAN_DURATION_IN_SECONDS_STUB;
-    const status = props.status ?? CreditStatus.Nonexistent;
-    const loanAmount = props.loanAmount ?? LOAN_AMOUNT_STUB;
-    const loanAddon = props.loanAddon ?? LOAN_ADDON_STUB;
-    const loanId = props.loanId ?? 0n;
+  function defineCredit(props: Partial<Credit> = {}): Credit {
     return {
-      borrower: borrowerAddress,
-      programId,
-      durationInPeriods,
-      status,
-      loanAmount,
-      loanAddon,
-      loanId
+      ...initialCredit,
+      borrower: props.borrower ?? borrower.address,
+      programId: props.programId ?? LOAN_PROGRAM_ID_STUB,
+      durationInPeriods: props.durationInPeriods ?? LOAN_DURATION_IN_SECONDS_STUB,
+      status: props.status ?? CreditStatus.Nonexistent,
+      loanAmount: props.loanAmount ?? LOAN_AMOUNT_STUB,
+      loanAddon: props.loanAddon ?? LOAN_ADDON_STUB,
+      loanId: props.loanId ?? 0n
     };
   }
 
@@ -306,11 +344,94 @@ describe("Contract 'CreditAgent'", async () => {
     );
     await expect(tx).to.emit(cashierMock, EVENT_NAME_MOCK_CONFIGURE_CASH_OUT_HOOKS_CALLED).withArgs(
       txId,
-      getAddress(creditAgent), // newCallableContract,
+      getAddress(creditAgent), // newCallableContract
       NEEDED_CASHIER_CASH_OUT_HOOK_FLAGS // newHookFlags
     );
     credit.status = CreditStatus.Initiated;
     checkEquality(await creditAgent.getCredit(txId) as Credit, credit);
+  }
+
+  async function deployAndConfigureContractsThenInitiateInstallmentCredit(): Promise<{
+    fixture: Fixture;
+    txId: string;
+    initCredit: InstallmentCredit;
+    initCashOut: CashOut;
+  }> {
+    const fixture = await deployAndConfigureContracts();
+    const { creditAgent, cashierMock } = fixture;
+    const txId = TX_ID_STUB_INSTALLMENT;
+    const initCredit = defineInstallmentCredit();
+    const initCashOut: CashOut = {
+      ...initialCashOut,
+      account: borrower.address,
+      amount: initCredit.borrowAmounts.reduce((acc, val) => acc + val, 0n)
+    };
+
+    await proveTx(initiateInstallmentCredit(creditAgent, { txId, credit: initCredit }));
+    await proveTx(cashierMock.setCashOut(txId, initCashOut));
+
+    return { fixture, txId, initCredit, initCashOut };
+  }
+
+  function defineInstallmentCredit(props: Partial<InstallmentCredit> = {}): InstallmentCredit {
+    return {
+      ...initialInstallmentCredit,
+      borrower: props.borrower ?? borrower.address,
+      programId: props.programId ?? LOAN_PROGRAM_ID_STUB,
+      status: props.status ?? CreditStatus.Nonexistent,
+      durationsInPeriods: props.durationsInPeriods ?? [10, 20],
+      borrowAmounts: props.borrowAmounts ?? [BigInt(1000), BigInt(2000)],
+      addonAmounts: props.addonAmounts ?? [BigInt(100), BigInt(200)],
+      firstInstallmentId: props.firstInstallmentId ?? 0n
+    };
+  }
+
+  function initiateInstallmentCredit(
+    creditAgent: Contract,
+    props: {
+      txId?: string;
+      credit?: InstallmentCredit;
+      caller?: HardhatEthersSigner;
+    } = {}
+  ): Promise<TransactionResponse> {
+    const caller = props.caller ?? manager;
+    const txId = props.txId ?? TX_ID_STUB_INSTALLMENT;
+    const credit = props.credit ?? defineInstallmentCredit();
+    return connect(creditAgent, caller).initiateInstallmentCredit(
+      txId,
+      credit.borrower,
+      credit.programId,
+      credit.durationsInPeriods,
+      credit.borrowAmounts,
+      credit.addonAmounts
+    );
+  }
+
+  async function checkInstallmentCreditInitiation(fixture: Fixture, props: {
+    tx: Promise<TransactionResponse>;
+    txId: string;
+    credit: InstallmentCredit;
+  }) {
+    const { creditAgent, cashierMock } = fixture;
+    const { tx, txId, credit } = props;
+    await expect(tx).to.emit(creditAgent, EVENT_NAME_INSTALLMENT_CREDIT_STATUS_CHANGED).withArgs(
+      txId,
+      credit.borrower,
+      CreditStatus.Initiated, // newStatus
+      CreditStatus.Nonexistent, // oldStatus
+      credit.firstInstallmentId,
+      credit.programId,
+      credit.durationsInPeriods,
+      credit.borrowAmounts,
+      credit.addonAmounts
+    );
+    await expect(tx).to.emit(cashierMock, EVENT_NAME_MOCK_CONFIGURE_CASH_OUT_HOOKS_CALLED).withArgs(
+      txId,
+      getAddress(creditAgent), // newCallableContract
+      NEEDED_CASHIER_CASH_OUT_HOOK_FLAGS // newHookFlags
+    );
+    credit.status = CreditStatus.Initiated;
+    checkEquality(await creditAgent.getInstallmentCredit(txId) as InstallmentCredit, credit);
   }
 
   describe("Function 'initialize()'", async () => {
@@ -681,7 +802,7 @@ describe("Contract 'CreditAgent'", async () => {
 
       it("The provided borrower address is zero", async () => {
         const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
-        const credit = defineCredit({ borrowerAddress: ADDRESS_ZERO });
+        const credit = defineCredit({ borrower: ADDRESS_ZERO });
 
         await expect(
           initiateCredit(creditAgent, { credit })
@@ -852,7 +973,7 @@ describe("Contract 'CreditAgent'", async () => {
     // Additional more complex checks are in the other sections
   });
 
-  describe("Function 'onCashierHook()", async () => {
+  describe("Function 'onCashierHook()'", async () => {
     async function checkCashierHookCalling(fixture: Fixture, props: {
       txId: string;
       credit: Credit;
@@ -1102,7 +1223,7 @@ describe("Contract 'CreditAgent'", async () => {
 
         await expect(
           cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId)
-        ).to.revertedWithCustomError(
+        ).to.be.revertedWithCustomError(
           creditAgent,
           REVERT_ERROR_IF_CASH_OUT_PARAMETERS_INAPPROPRIATE
         ).withArgs(txId);
@@ -1119,7 +1240,7 @@ describe("Contract 'CreditAgent'", async () => {
 
         await expect(
           cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId)
-        ).to.revertedWithCustomError(
+        ).to.be.revertedWithCustomError(
           creditAgent,
           REVERT_ERROR_IF_CASH_OUT_PARAMETERS_INAPPROPRIATE
         ).withArgs(txId);
@@ -1177,6 +1298,7 @@ describe("Contract 'CreditAgent'", async () => {
       const tx = initiateCredit(creditAgent, { txId, credit });
       await checkCreditInitiation(fixture, { tx, txId, credit });
       const expectedAgentState: AgentState = {
+        ...initialAgentState,
         initiatedCreditCounter: 1n,
         pendingCreditCounter: 0n,
         configured: true
@@ -1301,6 +1423,747 @@ describe("Contract 'CreditAgent'", async () => {
 
       // Configuring is prohibited if a credit is initiated
       await proveTx(initiateCredit(creditAgent, { txId, credit }));
+      await checkConfiguringProhibition();
+
+      // Configuring is allowed if credits are reversed or confirmed and no more active credits exist
+      await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId));
+      await proveTx(
+        cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutConfirmationAfter, txId)
+      );
+      await checkConfiguringAllowance();
+    });
+  });
+
+  describe("Function 'initiateInstallmentCredit()'", async () => {
+    describe("Executes as expected if", async () => {
+      it("The 'addonAmounts' values are not zero", async () => {
+        const fixture = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({ addonAmounts: [LOAN_ADDON_STUB, LOAN_ADDON_STUB] });
+        const txId = TX_ID_STUB_INSTALLMENT;
+        const tx = initiateInstallmentCredit(fixture.creditAgent, { txId, credit });
+        await checkInstallmentCreditInitiation(fixture, { tx, txId, credit });
+      });
+      it("The 'addonAmounts' values are zero", async () => {
+        const fixture = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({ addonAmounts: [0n, 0n] });
+        const txId = TX_ID_STUB_INSTALLMENT;
+        const tx = initiateInstallmentCredit(fixture.creditAgent, { txId, credit });
+        await checkInstallmentCreditInitiation(fixture, { tx, txId, credit });
+      });
+    });
+
+    describe("Is reverted if", async () => {
+      it("The contract is paused", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        await proveTx(creditAgent.pause());
+
+        await expect(
+          initiateInstallmentCredit(creditAgent)
+        ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("The caller does not have the manager role", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+
+        await expect(
+          initiateInstallmentCredit(creditAgent, { caller: deployer })
+        ).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_UNAUTHORIZED_ACCOUNT
+        ).withArgs(deployer.address, managerRole);
+      });
+
+      it("The 'Cashier' contract address is not configured", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        await proveTx(creditAgent.setCashier(ADDRESS_ZERO));
+
+        await expect(
+          initiateInstallmentCredit(creditAgent)
+        ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_CONTRACT_NOT_CONFIGURED);
+      });
+
+      it("The 'LendingMarket' contract address is not configured", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        await proveTx(creditAgent.setLendingMarket(ADDRESS_ZERO));
+
+        await expect(
+          initiateInstallmentCredit(creditAgent)
+        ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_CONTRACT_NOT_CONFIGURED);
+      });
+
+      it("The provided 'txId' value is zero", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({});
+
+        await expect(
+          initiateInstallmentCredit(creditAgent, { txId: TX_ID_ZERO, credit })
+        ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_TX_ID_ZERO);
+      });
+
+      it("The provided borrower address is zero", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({ borrower: ADDRESS_ZERO });
+
+        await expect(
+          initiateInstallmentCredit(creditAgent, { credit })
+        ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_BORROWER_ADDRESS_ZERO);
+      });
+
+      it("The provided program ID is zero", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({ programId: 0 });
+
+        await expect(
+          initiateInstallmentCredit(creditAgent, { credit })
+        ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_PROGRAM_ID_ZERO);
+      });
+
+      it("The provided loan duration is zero", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({ durationsInPeriods: [0, 20] });
+
+        await expect(
+          initiateInstallmentCredit(creditAgent, { credit })
+        ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_LOAN_DURATION_ZERO);
+      });
+
+      it("The provided loan amount is zero", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({ borrowAmounts: [100n, 0n] });
+
+        await expect(
+          initiateInstallmentCredit(creditAgent, { credit })
+        ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_LOAN_AMOUNT_ZERO);
+      });
+
+      it("A credit is already initiated for the provided transaction ID", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit();
+        const txId = TX_ID_STUB_INSTALLMENT;
+        await proveTx(initiateInstallmentCredit(creditAgent, { txId, credit }));
+
+        await expect(
+          initiateInstallmentCredit(creditAgent, { txId, credit })
+        ).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_CREDIT_STATUS_INAPPROPRIATE
+        ).withArgs(
+          txId,
+          CreditStatus.Initiated // status
+        );
+      });
+
+      it("The 'programId' argument is greater than unsigned 32-bit integer", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({ programId: Math.pow(2, 32) });
+        await expect(
+          initiateInstallmentCredit(creditAgent, { credit })
+        ).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_SAFE_CAST_OVERFLOWED_UINT_DOWNCAST
+        ).withArgs(32, credit.programId);
+      });
+
+      it("The 'durationInPeriods' argument is greater than unsigned 32-bit integer", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({ durationsInPeriods: [Math.pow(2, 32), 20] });
+        await expect(
+          initiateInstallmentCredit(creditAgent, { credit })
+        ).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_SAFE_CAST_OVERFLOWED_UINT_DOWNCAST
+        ).withArgs(32, credit.durationsInPeriods[0]);
+      });
+
+      it("The 'loanAmount' argument is greater than unsigned 64-bit integer", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({ borrowAmounts: [100n, 2n ** 64n] });
+        await expect(
+          initiateInstallmentCredit(creditAgent, { credit })
+        ).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_SAFE_CAST_OVERFLOWED_UINT_DOWNCAST
+        ).withArgs(64, credit.borrowAmounts[1]);
+      });
+
+      it("The 'loanAddon' argument is greater than unsigned 64-bit integer", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({ addonAmounts: [100n, 2n ** 64n] });
+        await expect(
+          initiateInstallmentCredit(creditAgent, { credit })
+        ).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_SAFE_CAST_OVERFLOWED_UINT_DOWNCAST
+        ).withArgs(64, credit.addonAmounts[1]);
+      });
+
+      it("The 'durationsInPeriods' array has different length than other arrays", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({
+          durationsInPeriods: [10],
+          borrowAmounts: [1000n, 2000n],
+          addonAmounts: [100n, 200n]
+        });
+        await expect(initiateInstallmentCredit(creditAgent, { credit })).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_INVALID_INPUT_ARRAYS
+        );
+      });
+
+      it("The 'borrowAmounts' array has different length than other arrays", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({
+          durationsInPeriods: [10, 20],
+          borrowAmounts: [1000n],
+          addonAmounts: [100n, 200n]
+        });
+        await expect(initiateInstallmentCredit(creditAgent, { credit })).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_INVALID_INPUT_ARRAYS
+        );
+      });
+
+      it("The 'addonAmounts' array has different length than other arrays", async () => {
+        const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+        const credit = defineInstallmentCredit({
+          durationsInPeriods: [10, 20],
+          borrowAmounts: [1000n, 2000n],
+          addonAmounts: [100n]
+        });
+        await expect(initiateInstallmentCredit(creditAgent, { credit })).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_INVALID_INPUT_ARRAYS
+        );
+      });
+
+      // Additional more complex checks are in the other sections
+    });
+  });
+
+  describe("Function 'revokeInstallmentCredit()", async () => {
+    it("Executes as expected", async () => {
+      const { creditAgent, cashierMock } = await setUpFixture(deployAndConfigureContracts);
+      const credit = defineInstallmentCredit();
+      const txId = TX_ID_STUB_INSTALLMENT;
+      await proveTx(initiateInstallmentCredit(creditAgent, { txId, credit }));
+
+      const tx = connect(creditAgent, manager).revokeInstallmentCredit(txId);
+      await expect(tx).to.emit(creditAgent, EVENT_NAME_INSTALLMENT_CREDIT_STATUS_CHANGED).withArgs(
+        txId,
+        credit.borrower,
+        CreditStatus.Nonexistent, // newStatus
+        CreditStatus.Initiated, // oldStatus
+        credit.firstInstallmentId,
+        credit.programId,
+        credit.durationsInPeriods,
+        credit.borrowAmounts,
+        credit.addonAmounts
+      );
+      await expect(tx).to.emit(cashierMock, EVENT_NAME_MOCK_CONFIGURE_CASH_OUT_HOOKS_CALLED).withArgs(
+        txId,
+        ADDRESS_ZERO, // newCallableContract,
+        0 // newHookFlags
+      );
+      checkEquality(await creditAgent.getCredit(txId) as Credit, initialCredit);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+      await proveTx(creditAgent.pause());
+
+      await expect(
+        connect(creditAgent, manager).revokeInstallmentCredit(TX_ID_STUB_INSTALLMENT)
+      ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the manager role", async () => {
+      const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+
+      await expect(
+        connect(creditAgent, deployer).revokeInstallmentCredit(TX_ID_STUB_INSTALLMENT)
+      ).to.be.revertedWithCustomError(
+        creditAgent,
+        REVERT_ERROR_IF_UNAUTHORIZED_ACCOUNT
+      ).withArgs(deployer.address, managerRole);
+    });
+
+    it("Is reverted if the provided 'txId' value is zero", async () => {
+      const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+
+      await expect(
+        connect(creditAgent, manager).revokeInstallmentCredit(TX_ID_ZERO)
+      ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_TX_ID_ZERO);
+    });
+
+    it("Is reverted if the credit does not exist", async () => {
+      const { creditAgent } = await setUpFixture(deployAndConfigureContracts);
+
+      await expect(
+        connect(creditAgent, manager).revokeInstallmentCredit(TX_ID_STUB_INSTALLMENT)
+      ).to.be.revertedWithCustomError(
+        creditAgent,
+        REVERT_ERROR_IF_CREDIT_STATUS_INAPPROPRIATE
+      ).withArgs(
+        TX_ID_STUB_INSTALLMENT,
+        CreditStatus.Nonexistent // status
+      );
+    });
+
+    // Additional more complex checks are in the other sections
+  });
+
+  describe("Function 'onCashierHook()' for installment credit", async () => {
+    async function checkCashierHookCalling(fixture: Fixture, props: {
+      txId: string;
+      credit: InstallmentCredit;
+      hookIndex: HookIndex;
+      newCreditStatus: CreditStatus;
+      oldCreditStatus: CreditStatus;
+    }) {
+      const { creditAgent, cashierMock, lendingMarketMock } = fixture;
+      const { credit, txId, hookIndex, newCreditStatus, oldCreditStatus } = props;
+
+      const tx = cashierMock.callCashierHook(getAddress(creditAgent), hookIndex, txId);
+
+      credit.status = newCreditStatus;
+
+      if (oldCreditStatus !== newCreditStatus) {
+        await expect(tx).to.emit(creditAgent, EVENT_NAME_INSTALLMENT_CREDIT_STATUS_CHANGED).withArgs(
+          txId,
+          credit.borrower,
+          newCreditStatus,
+          oldCreditStatus,
+          credit.firstInstallmentId,
+          credit.programId,
+          credit.durationsInPeriods,
+          credit.borrowAmounts,
+          credit.addonAmounts
+        );
+        if (newCreditStatus == CreditStatus.Pending) {
+          await expect(tx).to.emit(lendingMarketMock, EVENT_NAME_MOCK_TAKE_INSTALLMENT_LOAN_FOR_CALLED).withArgs(
+            credit.borrower,
+            credit.programId,
+            credit.borrowAmounts,
+            credit.addonAmounts,
+            credit.durationsInPeriods
+          );
+        } else {
+          await expect(tx).not.to.emit(lendingMarketMock, EVENT_NAME_MOCK_TAKE_INSTALLMENT_LOAN_FOR_CALLED);
+        }
+
+        if (newCreditStatus == CreditStatus.Reversed) {
+          await expect(tx).to.emit(lendingMarketMock, EVENT_NAME_MOCK_REVOKE_INSTALLMENT_LOAN_CALLED).withArgs(credit.firstInstallmentId);
+        } else {
+          await expect(tx).not.to.emit(lendingMarketMock, EVENT_NAME_MOCK_REVOKE_INSTALLMENT_LOAN_CALLED);
+        }
+      } else {
+        await expect(tx).not.to.emit(creditAgent, EVENT_NAME_INSTALLMENT_CREDIT_STATUS_CHANGED);
+      }
+
+      checkEquality(await creditAgent.getInstallmentCredit(txId) as InstallmentCredit, credit);
+    }
+
+    describe("Executes as expected if", async () => {
+      it("A cash-out requested and then confirmed with other proper conditions", async () => {
+        const { fixture, txId, initCredit } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+        const expectedAgentState: AgentState = {
+          ...initialAgentState,
+          initiatedInstallmentCreditCounter: 1n,
+          configured: true
+        };
+        checkEquality(await fixture.creditAgent.agentState() as AgentState, expectedAgentState);
+        const credit: InstallmentCredit = { ...initCredit, firstInstallmentId: fixture.loanIdStub };
+
+        // Emulate cash-out request
+        await checkCashierHookCalling(
+          fixture,
+          {
+            txId,
+            credit,
+            hookIndex: HookIndex.CashOutRequestBefore,
+            newCreditStatus: CreditStatus.Pending,
+            oldCreditStatus: CreditStatus.Initiated
+          }
+        );
+        expectedAgentState.initiatedInstallmentCreditCounter = 0n;
+        expectedAgentState.pendingInstallmentCreditCounter = 1n;
+        checkEquality(await fixture.creditAgent.agentState() as AgentState, expectedAgentState);
+
+        // Emulate cash-out confirmation
+        await checkCashierHookCalling(
+          fixture,
+          {
+            txId,
+            credit,
+            hookIndex: HookIndex.CashOutConfirmationAfter,
+            newCreditStatus: CreditStatus.Confirmed,
+            oldCreditStatus: CreditStatus.Pending
+          }
+        );
+        expectedAgentState.pendingInstallmentCreditCounter = 0n;
+        checkEquality(await fixture.creditAgent.agentState() as AgentState, expectedAgentState);
+      });
+
+      it("A cash-out requested and then reversed with other proper conditions", async () => {
+        const { fixture, txId, initCredit } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+        const credit: InstallmentCredit = { ...initCredit, firstInstallmentId: fixture.loanIdStub };
+
+        // Emulate cash-out request
+        await checkCashierHookCalling(
+          fixture,
+          {
+            txId,
+            credit,
+            hookIndex: HookIndex.CashOutRequestBefore,
+            newCreditStatus: CreditStatus.Pending,
+            oldCreditStatus: CreditStatus.Initiated
+          }
+        );
+        const expectedAgentState: AgentState = {
+          ...initialAgentState,
+          pendingInstallmentCreditCounter: 1n,
+          configured: true
+        };
+        checkEquality(await fixture.creditAgent.agentState() as AgentState, expectedAgentState);
+
+        // Emulate cash-out reversal
+        await checkCashierHookCalling(
+          fixture,
+          {
+            txId,
+            credit,
+            hookIndex: HookIndex.CashOutReversalAfter,
+            newCreditStatus: CreditStatus.Reversed,
+            oldCreditStatus: CreditStatus.Pending
+          }
+        );
+        expectedAgentState.pendingInstallmentCreditCounter = 0n;
+        checkEquality(await fixture.creditAgent.agentState() as AgentState, expectedAgentState);
+      });
+    });
+
+    describe("Is reverted if", async () => {
+      async function checkCashierHookInappropriateStatusError(fixture: Fixture, props: {
+        txId: string;
+        hookIndex: HookIndex;
+        CreditStatus: CreditStatus;
+      }) {
+        const { creditAgent, cashierMock } = fixture;
+        const { txId, hookIndex, CreditStatus } = props;
+        await expect(
+          cashierMock.callCashierHook(getAddress(creditAgent), hookIndex, TX_ID_STUB_INSTALLMENT)
+        ).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_CREDIT_STATUS_INAPPROPRIATE
+        ).withArgs(
+          txId,
+          CreditStatus // status
+        );
+      }
+
+      it("The contract is paused (DUPLICATE)", async () => {
+        const { fixture } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+        const { creditAgent, cashierMock } = fixture;
+        const hookIndex = HookIndex.CashOutRequestBefore;
+        await proveTx(creditAgent.pause());
+
+        await expect(
+          cashierMock.callCashierHook(getAddress(creditAgent), hookIndex, TX_ID_STUB)
+        ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("The caller is not the configured 'Cashier' contract (DUPLICATE)", async () => {
+        const { fixture } = await setUpFixture(deployAndConfigureContractsThenInitiateCredit);
+        const { creditAgent } = fixture;
+        const hookIndex = HookIndex.CashOutRequestBefore;
+
+        await expect(
+          connect(creditAgent, deployer).onCashierHook(hookIndex, TX_ID_STUB)
+        ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_CASHIER_HOOK_CALLER_UNAUTHORIZED);
+      });
+
+      it("The credit status is inappropriate to the provided hook index. Part 1", async () => {
+        const { fixture, txId } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+        const { creditAgent, cashierMock } = fixture;
+
+        // Try for a credit with the initiated status
+        await checkCashierHookInappropriateStatusError(fixture, {
+          txId,
+          hookIndex: HookIndex.CashOutConfirmationAfter,
+          CreditStatus: CreditStatus.Initiated
+        });
+        await checkCashierHookInappropriateStatusError(fixture, {
+          txId,
+          hookIndex: HookIndex.CashOutReversalAfter,
+          CreditStatus: CreditStatus.Initiated
+        });
+
+        // Try for a credit with the pending status
+        await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId));
+        await checkCashierHookInappropriateStatusError(fixture, {
+          txId,
+          hookIndex: HookIndex.CashOutRequestBefore,
+          CreditStatus: CreditStatus.Pending
+        });
+
+        // Try for a credit with the confirmed status
+        await proveTx(
+          cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutConfirmationAfter, txId)
+        );
+        await checkCashierHookInappropriateStatusError(fixture, {
+          txId,
+          hookIndex: HookIndex.CashOutRequestBefore,
+          CreditStatus: CreditStatus.Confirmed
+        });
+        await checkCashierHookInappropriateStatusError(fixture, {
+          txId,
+          hookIndex: HookIndex.CashOutConfirmationAfter,
+          CreditStatus: CreditStatus.Confirmed
+        });
+        await checkCashierHookInappropriateStatusError(fixture, {
+          txId,
+          hookIndex: HookIndex.CashOutReversalAfter,
+          CreditStatus: CreditStatus.Confirmed
+        });
+      });
+
+      it("The credit status is inappropriate to the provided hook index. Part 2", async () => {
+        const { fixture, txId } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+        const { creditAgent, cashierMock } = fixture;
+
+        // Try for a credit with the reversed status
+        await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId));
+        await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutReversalAfter, txId));
+        await checkCashierHookInappropriateStatusError(fixture, {
+          txId,
+          hookIndex: HookIndex.CashOutRequestBefore,
+          CreditStatus: CreditStatus.Reversed
+        });
+        await checkCashierHookInappropriateStatusError(fixture, {
+          txId,
+          hookIndex: HookIndex.CashOutConfirmationAfter,
+          CreditStatus: CreditStatus.Reversed
+        });
+        await checkCashierHookInappropriateStatusError(fixture, {
+          txId,
+          hookIndex: HookIndex.CashOutReversalAfter,
+          CreditStatus: CreditStatus.Reversed
+        });
+      });
+
+      it("The cash-out account is not match the credit borrower before taking a loan", async () => {
+        const { fixture, txId, initCashOut } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+        const { creditAgent, cashierMock } = fixture;
+        const cashOut: CashOut = {
+          ...initCashOut,
+          account: deployer.address
+        };
+        await proveTx(cashierMock.setCashOut(txId, cashOut));
+
+        await expect(
+          cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId)
+        ).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_CASH_OUT_PARAMETERS_INAPPROPRIATE
+        ).withArgs(txId);
+      });
+
+      it("The cash-out amount is not match the credit amount before taking a loan", async () => {
+        const { fixture, txId, initCashOut } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+        const { creditAgent, cashierMock } = fixture;
+        const cashOut: CashOut = {
+          ...initCashOut,
+          amount: initCashOut.amount + 1n
+        };
+        await proveTx(cashierMock.setCashOut(txId, cashOut));
+
+        await expect(
+          cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId)
+        ).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_CASH_OUT_PARAMETERS_INAPPROPRIATE
+        ).withArgs(txId);
+      });
+
+      it("The provided hook index is unexpected", async () => {
+        const { fixture } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+        const { creditAgent, cashierMock } = fixture;
+        const hookIndex = HookIndex.Unused;
+
+        await expect(
+          cashierMock.callCashierHook(getAddress(creditAgent), hookIndex, TX_ID_STUB)
+        ).to.be.revertedWithCustomError(
+          creditAgent,
+          REVERT_ERROR_IF_CASHIER_HOOK_INDEX_UNEXPECTED
+        ).withArgs(
+          hookIndex,
+          TX_ID_STUB,
+          getAddress(cashierMock)
+        );
+      });
+    });
+  });
+
+  describe("Complex scenarios for installment credit", async () => {
+    it("A revoked credit can be re-initiated", async () => {
+      const { fixture, txId, initCredit } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+      const { creditAgent } = fixture;
+      const expectedAgentState: AgentState = {
+        ...initialAgentState,
+        initiatedInstallmentCreditCounter: 1n,
+        configured: true
+      };
+      const credit: InstallmentCredit = { ...initCredit };
+      checkEquality(await fixture.creditAgent.agentState() as AgentState, expectedAgentState);
+
+      await proveTx(connect(creditAgent, manager).revokeInstallmentCredit(txId));
+      expectedAgentState.initiatedInstallmentCreditCounter = 0n;
+      checkEquality(await fixture.creditAgent.agentState() as AgentState, expectedAgentState);
+
+      const tx = initiateInstallmentCredit(creditAgent, { txId, credit });
+      await checkInstallmentCreditInitiation(fixture, { tx, txId, credit });
+      expectedAgentState.initiatedInstallmentCreditCounter = 1n;
+      checkEquality(await fixture.creditAgent.agentState() as AgentState, expectedAgentState);
+    });
+
+    it("A reversed credit can be re-initiated", async () => {
+      const { fixture, txId, initCredit } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+      const { creditAgent, cashierMock } = fixture;
+      const credit: InstallmentCredit = { ...initCredit };
+
+      await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId));
+      await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutReversalAfter, txId));
+
+      const tx = initiateInstallmentCredit(creditAgent, { txId, credit });
+      await checkInstallmentCreditInitiation(fixture, { tx, txId, credit });
+      const expectedAgentState: AgentState = {
+        ...initialAgentState,
+        initiatedInstallmentCreditCounter: 1n,
+        pendingInstallmentCreditCounter: 0n,
+        configured: true
+      };
+      checkEquality(await fixture.creditAgent.agentState() as AgentState, expectedAgentState);
+    });
+
+    it("A pending or confirmed credit cannot be re-initiated", async () => {
+      const { fixture, txId, initCredit } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+      const { creditAgent, cashierMock } = fixture;
+      const credit: InstallmentCredit = { ...initCredit };
+
+      // Try for a credit with the pending status
+      await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId));
+      await expect(
+        initiateInstallmentCredit(creditAgent, { txId, credit })
+      ).to.be.revertedWithCustomError(
+        creditAgent,
+        REVERT_ERROR_IF_CREDIT_STATUS_INAPPROPRIATE
+      ).withArgs(
+        txId,
+        CreditStatus.Pending // status
+      );
+
+      // confirm => confirmed
+      await proveTx(
+        cashierMock.callCashierHook(
+          getAddress(creditAgent),
+          HookIndex.CashOutConfirmationAfter,
+          txId
+        )
+      );
+      // try re-initiate => revert with status=Confirmed
+      await expect(
+        initiateInstallmentCredit(creditAgent, { txId, credit })
+      ).to.be.revertedWithCustomError(
+        creditAgent,
+        REVERT_ERROR_IF_CREDIT_STATUS_INAPPROPRIATE
+      ).withArgs(txId, CreditStatus.Confirmed);
+    });
+
+    it("A credit with any status except initiated cannot be revoked", async () => {
+      const { fixture, txId, initCredit } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+      const { creditAgent, cashierMock } = fixture;
+      const credit: InstallmentCredit = { ...initCredit };
+
+      // Try for a credit with the pending status
+      await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId));
+      await expect(
+        connect(creditAgent, manager).revokeInstallmentCredit(txId)
+      ).to.be.revertedWithCustomError(
+        creditAgent,
+        REVERT_ERROR_IF_CREDIT_STATUS_INAPPROPRIATE
+      ).withArgs(
+        txId,
+        CreditStatus.Pending // status
+      );
+
+      // Try for a credit with the reversed status
+      await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutReversalAfter, txId));
+      await expect(
+        connect(creditAgent, manager).revokeInstallmentCredit(txId)
+      ).to.be.revertedWithCustomError(
+        creditAgent,
+        REVERT_ERROR_IF_CREDIT_STATUS_INAPPROPRIATE
+      ).withArgs(
+        txId,
+        CreditStatus.Reversed // status
+      );
+
+      // Try for a credit with the confirmed status
+      await proveTx(initiateInstallmentCredit(creditAgent, { txId, credit }));
+      await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId));
+      await proveTx(
+        cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutConfirmationAfter, txId)
+      );
+      await expect(
+        connect(creditAgent, manager).revokeInstallmentCredit(txId)
+      ).to.be.revertedWithCustomError(
+        creditAgent,
+        REVERT_ERROR_IF_CREDIT_STATUS_INAPPROPRIATE
+      ).withArgs(
+        txId,
+        CreditStatus.Confirmed // status
+      );
+    });
+
+    it("Configuring is prohibited when not all credits are processed", async () => {
+      const { fixture, txId, initCredit } = await setUpFixture(deployAndConfigureContractsThenInitiateInstallmentCredit);
+      const { creditAgent, cashierMock, lendingMarketMock } = fixture;
+      const credit: InstallmentCredit = { ...initCredit };
+
+      async function checkConfiguringProhibition() {
+        await expect(
+          connect(creditAgent, admin).setCashier(ADDRESS_ZERO)
+        ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_CONFIGURING_PROHIBITED);
+        await expect(
+          connect(creditAgent, admin).setLendingMarket(ADDRESS_ZERO)
+        ).to.be.revertedWithCustomError(creditAgent, REVERT_ERROR_IF_CONFIGURING_PROHIBITED);
+      }
+
+      async function checkConfiguringAllowance() {
+        await proveTx(connect(creditAgent, admin).setCashier(ADDRESS_ZERO));
+        await proveTx(connect(creditAgent, admin).setLendingMarket(ADDRESS_ZERO));
+        await proveTx(connect(creditAgent, admin).setCashier(getAddress(cashierMock)));
+        await proveTx(connect(creditAgent, admin).setLendingMarket(getAddress(lendingMarketMock)));
+      }
+
+      // Configuring is prohibited if a credit is initiated
+      await checkConfiguringProhibition();
+
+      // Configuring is allowed when no credit is initiated
+      await proveTx(connect(creditAgent, manager).revokeInstallmentCredit(txId));
+      await checkConfiguringAllowance();
+
+      // Configuring is prohibited if a credit is pending
+      await proveTx(initiateInstallmentCredit(creditAgent, { txId, credit }));
+      await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutRequestBefore, txId));
+      await checkConfiguringProhibition();
+
+      // Configuring is allowed if a credit is reversed and no more active credits exist
+      await proveTx(cashierMock.callCashierHook(getAddress(creditAgent), HookIndex.CashOutReversalAfter, txId));
+      await checkConfiguringAllowance();
+
+      // Configuring is prohibited if a credit is initiated
+      await proveTx(initiateInstallmentCredit(creditAgent, { txId, credit }));
       await checkConfiguringProhibition();
 
       // Configuring is allowed if credits are reversed or confirmed and no more active credits exist


### PR DESCRIPTION
## Main changes

1. The new grantor role has been introduced. This new role is needed to have an account other than the owner that can
   grant other roles to automate and simplify role management. The new role details:
    * purpose: grant and revoke other roles except itself and the owner one;
    * constant name: `GRANTOR_ROLE`;
    * hash definition code: `bytes32 public constant GRANTOR_ROLE =  keccak256("GRANTOR_ROLE")`.

2. The new `setRoleAdmin()` function has been added to arbitrarily assign role admins in the contract:

    <details>

    <summary>The definition of new function</summary>

    ```solidity
    /**
     * @notice Sets the admin role for a given role
     *
     * @dev This function is used to set the admin role for a given role
     * @param role The role to set the admin role for
     * @param adminRole The admin role to set
     */
    function setRoleAdmin(bytes32 role, bytes32 adminRole) external onlyOwner {....}
    ```

    </details>

3. Internal code reorganization and other minor improvements have been made. They do not affect the contract logic.

4. Improvements have been made to tests.

5. Project dependencies have been updated to the latest versions.

## Versioning

The smart contracts version has been updated to `v.1.3.0`.

## Migration steps

1. Upgrade the already deployed smart contracts. After the upgrade execute the further steps for each smart contract.

2. Configure the `OWNER_ROLE` role as the admin for the `GRANTOR_ROLE` role using the `setRoleAdmin()` function: `setRoleAdmin(GRANTOR_ROLE, OWNER_ROLE)`.

3. Configure the `GRANTOR_ROLE` role as the admin for the following already existing roles using the `setRoleAdmin()` function:
    * a. `ADMIN_ROLE`: `setRoleAdmin(ADMIN_ROLE, GRANTOR_ROLE)`;
    * b. `MANAGER_ROLE`: `setRoleAdmin(MANAGER_ROLE, GRANTOR_ROLE)`;
    * c. `PAUSER_ROLE`: `setRoleAdmin(PAUSER_ROLE, GRANTOR_ROLE)`;
    * d. `RESCUER_ROLE`: `setRoleAdmin(RESCUER_ROLE, GRANTOR_ROLE)`;

4. Grant the `GRANTOR_ROLE` role to the owner account: `grantRole(`GRANTOR_ROLE`, ownerAddress)`.

## Test Coverage

The changes have been fully covered by unit tests.

<details>

<summary>Test coverage details</summary>

| File                                    | % Stmts | % Branch | % Funcs | % Lines |
|-----------------------------------------|--------:|---------:|--------:|--------:|
| contracts/                              |  100.00 |   100.00 |  100.00 |  100.00 |
| ├─ CreditAgent.sol                      |  100.00 |   100.00 |  100.00 |  100.00 |
| ├─ CreditAgentStorage.sol               |  100.00 |   100.00 |  100.00 |  100.00 |
| contracts/base/                         |  100.00 |   100.00 |  100.00 |  100.00 |
| ├─ AccessControlExtUpgradeable.sol      |  100.00 |   100.00 |  100.00 |  100.00 |
| ├─ PausableExtUpgradeable.sol           |  100.00 |   100.00 |  100.00 |  100.00 |
| ├─ RescuableUpgradeable.sol             |  100.00 |   100.00 |  100.00 |  100.00 |
| ├─ UUPSExtUpgradeable.sol               |  100.00 |   100.00 |  100.00 |  100.00 |
| ├─ Versionable.sol                      |  100.00 |   100.00 |  100.00 |  100.00 |
| contracts/interfaces/                   |  100.00 |   100.00 |  100.00 |  100.00 |
| ├─ ICashier.sol                         |  100.00 |   100.00 |  100.00 |  100.00 |
| ├─ ICashierHook.sol                     |  100.00 |   100.00 |  100.00 |  100.00 |
| ├─ ICashierHookable.sol                 |  100.00 |   100.00 |  100.00 |  100.00 |
| ├─ ICreditAgent.sol                     |  100.00 |   100.00 |  100.00 |  100.00 |
| ├─ ILendingMarket.sol                   |  100.00 |   100.00 |  100.00 |  100.00 |
| ├─ IVersionable.sol                     |  100.00 |   100.00 |  100.00 |  100.00 |
| contracts/libraries/                    |  100.00 |   100.00 |  100.00 |  100.00 |
| ├─ SafeCast.sol                         |  100.00 |   100.00 |  100.00 |  100.00 |
| contracts/mocks/                        |  100.00 |   100.00 |  100.00 |  100.00 |
| ├─ CashierMock.sol                      |  100.00 |   100.00 |  100.00 |  100.00 |
| ├─ LendingMarketMock.sol                |  100.00 |   100.00 |  100.00 |  100.00 |
| contracts/mocks/base/                   |  100.00 |   100.00 |  100.00 |  100.00 |
| ├─ AccessControlExtUpgradeableMock.sol  |  100.00 |   100.00 |  100.00 |  100.00 |
| ├─ PausableExtUpgradeableMock.sol       |  100.00 |   100.00 |  100.00 |  100.00 |
| ├─ RescuableUpgradeableMock.sol         |  100.00 |   100.00 |  100.00 |  100.00 |
| ├─ UUPSExtUpgradeableMock.sol           |  100.00 |   100.00 |  100.00 |  100.00 |
| contracts/tokens/                       |  100.00 |   100.00 |  100.00 |  100.00 |
| ├─ ERC20TokenMock.sol                   |  100.00 |   100.00 |  100.00 |  100.00 |
| --------------------------------------- | ------- | -------- | ------- | ------- |
| **All files**                           |  100.00 |   100.00 |  100.00 |  100.00 |

</details>
